### PR TITLE
fix(CodeModal): CodeEditor should fill height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/preset-typescript": "^7.23.3",
         "@octokit/rest": "^18.0.0",
         "@patternfly/documentation-framework": "^6.0.0-alpha.121",
-        "@patternfly/patternfly": "^6.0.0",
+        "@patternfly/patternfly": "^6.1.0-prerelease.2",
         "@patternfly/react-icons": "^6.0.0",
         "@swc/core": "1.3.96",
         "@testing-library/dom": "^9.3.4",
@@ -3733,10 +3733,11 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.0.0.tgz",
-      "integrity": "sha512-Mn92Tt/4okSj1COGCJrgUgh390OOaFCWf0tL0WmigDNUecSHNn1D6Vhpd1hxHQBXvre9eWorzxV2b9yhSEl79Q==",
-      "dev": true
+      "version": "6.1.0-prerelease.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.1.0-prerelease.2.tgz",
+      "integrity": "sha512-zl0+3CH8A67iOEyitIEaNE6R1I4YXVqTRwHz8JJJEZcgfrqPN8Tst/Gz9N4hg/PBqGxBtj0lEJzP3s86rWm7kA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@patternfly/patternfly-a11y": {
       "version": "5.0.0",
@@ -28500,7 +28501,7 @@
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-code-editor": "^6.0.0",
-        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-core": "^6.1.0-prerelease.2",
         "@patternfly/react-icons": "^6.0.0",
         "clsx": "^2.1.0",
         "framer-motion": "^11.3.28",
@@ -28514,7 +28515,7 @@
       "devDependencies": {
         "@octokit/rest": "^18.0.0",
         "@patternfly/documentation-framework": "^6.0.6",
-        "@patternfly/patternfly": "^6.0.0",
+        "@patternfly/patternfly": "^6.1.0-prerelease.2",
         "@patternfly/patternfly-a11y": "^5.0.0",
         "@patternfly/react-table": "^6.0.0",
         "@types/dom-speech-recognition": "^0.0.4",
@@ -28543,6 +28544,55 @@
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
+      }
+    },
+    "packages/module/node_modules/@patternfly/react-core": {
+      "version": "6.1.0-prerelease.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0-prerelease.4.tgz",
+      "integrity": "sha512-RPQB4xPnzQmDLhuWFoiGujndhCbbX7EYw/t0eglWg1LseV6q2Vv3O1AoM94VxR0HQ4df9H9uZtZTYnRU+hvI+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@patternfly/react-icons": "^6.1.0-prerelease.1",
+        "@patternfly/react-styles": "^6.1.0-prerelease.1",
+        "@patternfly/react-tokens": "^6.1.0-prerelease.1",
+        "focus-trap": "7.6.1",
+        "react-dropzone": "^14.2.3",
+        "tslib": "^2.7.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "packages/module/node_modules/@patternfly/react-core/node_modules/@patternfly/react-icons": {
+      "version": "6.1.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0-prerelease.1.tgz",
+      "integrity": "sha512-Opd2kMRxKLkNAlFnEvfkt+Qsxfa3JQIo6s3L20fAQaiQEoNjaoSTdHqO/0KhJLXVEVKjAfjKlloPFyGe+0bVCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "packages/module/node_modules/@patternfly/react-styles": {
+      "version": "6.1.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0-prerelease.1.tgz",
+      "integrity": "sha512-iJu5aPm3+AsMz0P7to0taYCERVN+Wx/D422JF7rg/fH+g/9zgzPdU8rT/w20nPoHT8aOsmyB7sfo64gyfapSiQ==",
+      "license": "MIT"
+    },
+    "packages/module/node_modules/@patternfly/react-tokens": {
+      "version": "6.1.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0-prerelease.1.tgz",
+      "integrity": "sha512-d7XXo3/1tK86FxbAnMvKWnMuxQdTot+le8+hS0Jd6MIEqrVL2nJ3/hvcwAigN6M7LTsL5GrZ9NTaduuF3Xfd7Q==",
+      "license": "MIT"
+    },
+    "packages/module/node_modules/focus-trap": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.1.tgz",
+      "integrity": "sha512-nB8y4nQl8PshahLpGKZOq1sb0xrMVFSn6at7u/qOsBZTlZRzaapISGENcB6mOkoezbClZyiMwEF/dGY8AZ00rA==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
       }
     },
     "packages/module/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@octokit/rest": "^18.0.0",
     "@patternfly/documentation-framework": "^6.0.0-alpha.121",
-    "@patternfly/patternfly": "^6.0.0",
+    "@patternfly/patternfly": "^6.1.0-prerelease.2",
     "@patternfly/react-icons": "^6.0.0",
     "@swc/core": "1.3.96",
     "@testing-library/dom": "^9.3.4",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -31,7 +31,7 @@
     "tag": "prerelease"
   },
   "dependencies": {
-    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-core": "^6.1.0-prerelease.2",
     "@patternfly/react-code-editor": "^6.0.0",
     "@patternfly/react-icons": "^6.0.0",
     "clsx": "^2.1.0",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@patternfly/documentation-framework": "^6.0.6",
-    "@patternfly/patternfly": "^6.0.0",
+    "@patternfly/patternfly": "^6.1.0-prerelease.2",
     "@patternfly/patternfly-a11y": "^5.0.0",
     "@patternfly/react-table": "^6.0.0",
     "@types/dom-speech-recognition": "^0.0.4",

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -86,17 +86,6 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
     }
   };
 
-  /* eslint-disable indent */
-  const getHeight = (displayMode: ChatbotDisplayMode) => {
-    switch (displayMode) {
-      case ChatbotDisplayMode.docked:
-        return '100vh';
-      default:
-        return '45vh';
-    }
-  };
-  /* eslint-enable indent */
-
   const modal = (
     <Modal
       isOpen={isModalOpen}
@@ -116,6 +105,7 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
           <StackItem>
             <CodeEditor
               isDarkTheme
+              isFullHeight
               isLineNumbersVisible={isLineNumbersVisible}
               isLanguageLabelVisible
               isCopyEnabled={isCopyEnabled}
@@ -125,7 +115,6 @@ export const CodeModal: React.FunctionComponent<CodeModalProps> = ({
               onEditorDidMount={onEditorDidMount}
               onCodeChange={onCodeChange}
               className={codeEditorClassName}
-              height={getHeight(displayMode)}
               options={{
                 glyphMargin: false,
                 folding: false


### PR DESCRIPTION
Upgrading PatternFly to pull in a bug fix for the CodeEditor - this lets it flow to full height in our modals.

Looks like we may need to update the docs framework too.