### PR TITLE
fix(Chatbot): Handle zoom appropriately

### DIFF
--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -21,6 +21,18 @@
   &--hidden {
     pointer-events: none;
   }
+
+  // 32 rem is the width of the overlay chatbot plus the insets
+  // if the screen is smaller, we want to be 100%
+  @media screen and (max-width: 32rem) {
+    width: 100vw;
+    inset-inline-end: 0;
+  }
+
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    overflow: auto;
+  }
 }
 
 // ============================================================================
@@ -34,10 +46,22 @@
   border-radius: 0;
   box-shadow: var(--pf-t--global--box-shadow--lg--left);
   overflow: inherit;
+
+  // 30rem is the width of the docked chatbot
+  // if the screen is smaller, we want to be 100%
+  @media screen and (max-width: 30rem) {
+    width: 100%;
+  }
 }
 
 html.pf-chatbot-allow--docked {
   padding-right: 480px;
+
+  // 30rem is the width of the docked chatbot
+  // if the screen is smaller, we want to be 100%
+  @media screen and (max-width: 30rem) {
+    padding-right: 0px;
+  }
 }
 
 // ============================================================================
@@ -75,6 +99,11 @@ html.pf-chatbot-allow--docked {
   // Hide chatbot
   &--hidden {
     pointer-events: none;
+  }
+
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    overflow: auto;
   }
 }
 

--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -55,12 +55,12 @@
 }
 
 html.pf-chatbot-allow--docked {
-  padding-right: 480px;
+  padding-inline-start: 480px;
 
   // 30rem is the width of the docked chatbot
   // if the screen is smaller, we want to be 100%
   @media screen and (max-width: 30rem) {
-    padding-right: 0px;
+    padding-inline-start: 0px;
   }
 }
 

--- a/packages/module/src/ChatbotContent/ChatbotContent.scss
+++ b/packages/module/src/ChatbotContent/ChatbotContent.scss
@@ -7,6 +7,11 @@
   overflow-y: auto;
   overflow: hidden; // needed in Red Hat Developer Hub workspace
   flex: 1; // needed in Composer AI
+
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    overflow: unset;
+  }
 }
 
 // ============================================================================

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -39,3 +39,18 @@
   width: 100%;
   padding: var(--pf-t--global--spacer--md);
 }
+
+.pf-chatbot--default {
+  // allows for zoom conditions; try zooming to 200% to see
+  .pf-chatbot__dropzone--visible.pf-chatbot__dropzone {
+    @media screen and (max-height: 518px) {
+      display: flex;
+      height: 100%;
+      overflow: hidden;
+
+      .pf-v6-c-multiple-file-upload__main {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/packages/module/src/FileDropZone/FileDropZone.scss
+++ b/packages/module/src/FileDropZone/FileDropZone.scss
@@ -7,6 +7,11 @@
   overflow: hidden;
   display: grid;
   grid-template-rows: 1fr auto;
+
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    overflow-y: auto;
+  }
 }
 
 .pf-chatbot__dropzone--visible.pf-chatbot__dropzone {

--- a/packages/module/src/MessageBox/JumpButton.scss
+++ b/packages/module/src/MessageBox/JumpButton.scss
@@ -43,4 +43,9 @@
   &--bottom {
     inset-block-end: var(--pf-t--global--spacer--md) !important;
   }
+
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    display: none;
+  }
 }

--- a/packages/module/src/MessageBox/MessageBox.scss
+++ b/packages/module/src/MessageBox/MessageBox.scss
@@ -7,6 +7,16 @@
   flex-direction: column;
   row-gap: var(--pf-t--global--spacer--sm);
   padding: var(--pf-t--global--spacer--lg);
+
+  // 32 rem is the width of the overlay chatbot plus the insets
+  // if the screen is smaller, we want to be 100%
+  @media screen and (max-width: 32rem) {
+    width: 100%;
+  }
+  // allows for zoom conditions; try zooming to 200% to see
+  @media screen and (max-height: 518px) {
+    overflow-y: visible;
+  }
 }
 
 .pf-chatbot__messagebox--bottom > :first-child {


### PR DESCRIPTION
Allows entire chatbot to scroll like a normal website when zoom is high. Hides jump links since they won't work. Also adds responsive styles to chatbot on docked and overlay.

One example is here: https://chatbot-pr-chatbot-338.surge.sh/patternfly-ai/chatbot/overview/demo/basic-chatbot/; go to 150% or 200%.