### PR TITLE
fix(ChatbotConversationHistoryNav): Make order of drawer action buttons configurable

### DIFF
--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
@@ -93,6 +93,10 @@
     height: 100%;
   }
 
+  .pf-v6-c-drawer__actions--reversed {
+    flex-direction: row-reverse;
+  }
+
   // Close drawer
   .pf-v6-c-drawer__close {
     .pf-v6-c-button {

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { ChatbotDisplayMode } from '../Chatbot/Chatbot';
+import ChatbotConversationHistoryNav, { Conversation } from './ChatbotConversationHistoryNav';
+
+describe('ChatbotConversationHistoryNav', () => {
+  const onDrawerToggle = jest.fn();
+
+  const initialConversations: Conversation[] = [
+    {
+      id: '1',
+      text: 'Lightspeed documentation'
+    }
+  ];
+
+  it('should open the conversation history navigation drawer', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        conversations={initialConversations}
+      />
+    );
+    expect(screen.queryByText('Lightspeed documentation')).toBeInTheDocument();
+  });
+
+  it('should display the conversations for grouped conversations', () => {
+    const groupedConversations: { [key: string]: Conversation[] } = {
+      Today: [...initialConversations, { id: '2', text: 'Chatbot extension' }]
+    };
+
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        conversations={groupedConversations}
+      />
+    );
+    expect(screen.queryByText('Chatbot extension')).toBeInTheDocument();
+  });
+
+  it('should apply the reversed class when reverseButtonOrder is true', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder
+        conversations={initialConversations}
+      />
+    );
+
+    expect(screen.getByTestId('chatbot-nav-drawer-actions')).toHaveClass('pf-v6-c-drawer__actions--reversed');
+  });
+
+  it('should not apply the reversed class when reverseButtonOrder is false', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        conversations={initialConversations}
+      />
+    );
+    expect(screen.getByTestId('chatbot-nav-drawer-actions')).not.toHaveClass('pf-v6-c-drawer__actions--reversed');
+  });
+
+  it('should invoke handleTextInputChange callback when user searches for conversations', () => {
+    const handleSearch = jest.fn();
+    const groupedConversations: { [key: string]: Conversation[] } = {
+      Today: [...initialConversations, { id: '2', text: 'Chatbot extension' }]
+    };
+
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        conversations={groupedConversations}
+        handleTextInputChange={handleSearch}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText(/Search/i);
+
+    fireEvent.change(searchInput, { target: { value: 'Chatbot' } });
+
+    expect(handleSearch).toHaveBeenCalledWith('Chatbot');
+  });
+
+  it('should close the drawer when escape key is pressed', async () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+      />
+    );
+
+    fireEvent.keyDown(screen.getByPlaceholderText(/Search/i), {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27
+    });
+
+    waitFor(() => {
+      expect(screen.queryByText('Lightspeed documentation')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -72,6 +72,8 @@ export interface ChatbotConversationHistoryNavProps extends DrawerProps {
   handleTextInputChange?: (value: string) => void;
   /** Display mode of chatbot */
   displayMode: ChatbotDisplayMode;
+  /** Reverses the order of the drawer action buttons */
+  reverseButtonOrder?: boolean;
 }
 
 export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConversationHistoryNavProps> = ({
@@ -88,6 +90,7 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   searchInputAriaLabel = 'Filter menu items',
   handleTextInputChange,
   displayMode,
+  reverseButtonOrder = false,
   ...props
 }: ChatbotConversationHistoryNavProps) => {
   const drawerRef = React.useRef<HTMLDivElement>(null);
@@ -161,7 +164,10 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   const panelContent = (
     <DrawerPanelContent focusTrap={{ enabled: true }} minSize="384px" maxSize="384px">
       <DrawerHead>
-        <DrawerActions>
+        <DrawerActions
+          data-testid="chatbot-nav-drawer-actions"
+          className={reverseButtonOrder ? 'pf-v6-c-drawer__actions--reversed' : ''}
+        >
           <DrawerCloseButton onClick={onDrawerToggle} />
           {onNewChat && <Button onClick={onNewChat}>{newChatButtonText}</Button>}
         </DrawerActions>


### PR DESCRIPTION

**Fixes:**

https://github.com/patternfly/chatbot/issues/342

Add a prop `reverseButtonOrder` to change the order of the drawer action button, by default the button is set to false.


**Screenshots:**

code:

```javascript
    <ChatbotConversationHistoryNav
       ...
      reverseButtonOrder
      />
```



![chatbot_drawer_action](https://github.com/user-attachments/assets/7bdfcd0e-2276-4166-b1b3-6573971dda39)

**Unit tests:**

```
ChatbotConversationHistoryNav
    ✓ should open the conversation history navigation drawer (109 ms)
    ✓ should display the conversations for grouped conversations (24 ms)
    ✓ should apply the reversed class when reverseButtonOrder is true (21 ms)
    ✓ should not apply the reversed class when reverseButtonOrder is false (51 ms)
    ✓ should invoke handleTextInputChange callback when user searches for conversations (52 ms)
    ✓ should close the drawer when escape key is pressed (33 ms)
```