### PR TITLE
fix(SendButton): Adjust disabled state

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotMessageBarDisabled.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotMessageBarDisabled.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { MessageBar } from '@patternfly/chatbot/dist/dynamic/MessageBar';
+import { Checkbox } from '@patternfly/react-core';
+
+export const ChatbotMessageBarDisabledExample: React.FunctionComponent = () => {
+  const [isDisabled, setIsDisabled] = React.useState(false);
+  const handleSend = (message) => alert(message);
+
+  return (
+    <>
+      <Checkbox
+        label="Disable send button"
+        isChecked={isDisabled}
+        onChange={() => setIsDisabled(!isDisabled)}
+        id="disabled"
+        name="disabled"
+      />
+      <MessageBar
+        onSendMessage={handleSend}
+        isSendButtonDisabled={isDisabled}
+        alwayShowSendButton
+        hasAttachButton={false}
+      />
+    </>
+  );
+};

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
@@ -257,6 +257,14 @@ In this example, the locale is set to to ja-JP. You can try it out by saying "ha
 
 ```
 
+### Message bar with always-shown send button
+
+You can use the `alwaysShowSendButton` prop if you want to always show the send button. You may also wish to apply the `isSendButtonDisabled` prop. Sending via the enter key will be disabled when this is passed in, demonstrated in the example below. You may want to enable or disable the send button based on whether there is text in the message bar. Whether text is present in the input can be detected via the `onChange` prop for `<MessageBar>`.
+
+```js file="./ChatbotMessageBarDisabled.tsx"
+
+```
+
 ### Message bar with attach menu appended to attach button
 
 You can change the behavior of the attach button to open a menu, rather than the default file viewer for your operating system. This menu can display different actions related to attachments.

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
@@ -259,7 +259,11 @@ In this example, the locale is set to to ja-JP. You can try it out by saying "ha
 
 ### Message bar with always-shown send button
 
-You can use the `alwaysShowSendButton` prop if you want to always show the send button. You may also wish to apply the `isSendButtonDisabled` prop. Sending via the enter key will be disabled when this is passed in, demonstrated in the example below. You may want to enable or disable the send button based on whether there is text in the message bar. Whether text is present in the input can be detected via the `onChange` prop for `<MessageBar>`.
+By default, the send button is only shown once a user has entered a valid message. If you choose to keep the send button visible at all times, disable the button when there is no valid message to send.
+
+To always show the send button in the message bar, use the `alwaysShowSendButton` prop. Use the `isSendButtonDisabled` prop to disable the button as needed. If you want to enable or disable the send button based on the presence of text in the message bar, you can detect text via the `onChange` prop for `<MessageBar>`.
+
+To disable the send button in the following example, select the "Disable send button" checkbox. When the button is disabled, you also cannot send via the enter key.
 
 ```js file="./ChatbotMessageBarDisabled.tsx"
 

--- a/packages/module/src/MessageBar/SendButton.scss
+++ b/packages/module/src/MessageBar/SendButton.scss
@@ -7,13 +7,32 @@
   width: 3rem;
   height: 3rem;
 
+  .pf-v6-c-button__icon {
+    --pf-v6-c-button__icon--Color: var(--pf-t--global--color--brand--default);
+  }
+
   &:hover,
   &:focus {
     background-color: var(--pf-t--chatbot--blue-icon--background--color--hover);
+    color: var(--pf-t--global--color--brand--hover);
 
     .pf-v6-c-button__icon {
       color: var(--pf-t--chatbot--blue-icon--fill--hover);
     }
+  }
+}
+
+.pf-v6-theme-dark {
+  .pf-v6-c-button.pf-chatbot__button--send {
+    background-color: var(--pf-t--global--color--brand--default);
+    .pf-v6-c-button__icon {
+      --pf-v6-c-button__icon--Color: var(--pf-t--global--icon--color--inverse);
+    }
+  }
+
+  .pf-v6-c-button.pf-chatbot__button--send:hover,
+  .pf-v6-c-button.pf-chatbot__button--send:focus {
+    background-color: var(--pf-t--chatbot--blue-icon--background--color--hover);
   }
 }
 

--- a/packages/module/src/MessageBar/SendButton.scss
+++ b/packages/module/src/MessageBar/SendButton.scss
@@ -30,6 +30,11 @@
     }
   }
 
+  .pf-v6-c-button:disabled.pf-chatbot__button--send:disabled {
+    --pf-v6-c-button--disabled--Color: var(--pf-t--global--icon--color--disabled);
+    background-color: var(--pf-t--global--background--color--disabled--default);
+  }
+
   .pf-v6-c-button.pf-chatbot__button--send:hover,
   .pf-v6-c-button.pf-chatbot__button--send:focus {
     background-color: var(--pf-t--chatbot--blue-icon--background--color--hover);

--- a/packages/module/src/MessageBar/SendButton.tsx
+++ b/packages/module/src/MessageBar/SendButton.tsx
@@ -37,8 +37,8 @@ export const SendButton: React.FunctionComponent<SendButtonProps> = ({
     {...tooltipProps}
   >
     <Button
+      variant="plain"
       className={`pf-chatbot__button--send ${className ?? ''}`}
-      variant="link"
       aria-label={props['aria-label'] || 'Send button'}
       onClick={onClick}
       icon={

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -47,9 +47,9 @@
   --pf-t--chatbot--timing-function: cubic-bezier(0.77, 0, 0.175, 1);
 
   --pf-t--chatbot--blue-icon--background--color--hover: rgba(
-    185,
-    218,
-    252,
+    146,
+    197,
+    249,
     0.25
   ); // --pf-t--global--color--nonstatus--blue--default @ 25%
   --pf-t--chatbot--blue-icon--fill--hover: var(--pf-t--global--color--brand--hover);


### PR DESCRIPTION
Adjusted disabled state and also added a demo for always-shown send button, with an explanation on how to use it.

I migrated the button to an icon button so it picks up the same default styles Kayla's Figma kit has. This meant changing the default colors a bit for dark mode and light mode. I would appreciate a special eye on the send button in these states. I looked at Figma, but it's always helpful to get more 👀 on things.

This means that the button will now be more consistent with what's in Figma.

| State | Before | After |
|-|-|-|
| Light Default |<img width="70" alt="Screenshot 2024-12-06 at 1 47 16 PM" src="https://github.com/user-attachments/assets/47b288bc-ea6b-463e-aa75-5cca5622838e">|<img width="68" alt="Screenshot 2024-12-06 at 1 44 13 PM" src="https://github.com/user-attachments/assets/47030b4c-fc55-4144-bd42-dc4e1312f9fb">
| Light Hover |<img width="95" alt="Screenshot 2024-12-06 at 1 47 21 PM" src="https://github.com/user-attachments/assets/af5a3617-9aa2-4bb6-8d82-0bbc9a44a150">|<img width="87" alt="Screenshot 2024-12-06 at 1 54 51 PM" src="https://github.com/user-attachments/assets/e1a6b8fd-7122-478f-a505-a060a03ff218">
| Light Disabled |<img width="81" alt="Screenshot 2024-12-06 at 1 48 49 PM" src="https://github.com/user-attachments/assets/632005bd-6bfa-4222-b424-4fa33c176106">|<img width="82" alt="Screenshot 2024-12-06 at 1 45 32 PM" src="https://github.com/user-attachments/assets/7836cda0-95c0-4565-b2f8-a3cd2c222a31">
| Dark Default |<img width="69" alt="Screenshot 2024-12-06 at 1 47 26 PM" src="https://github.com/user-attachments/assets/f2bf6c81-f92b-4ee0-8e4b-31422b2fe30a">|<img width="98" alt="Screenshot 2024-12-06 at 1 44 06 PM" src="https://github.com/user-attachments/assets/dd125391-fdda-4861-9d8c-a49129113467">
| Dark Hover |<img width="91" alt="Screenshot 2024-12-06 at 1 47 30 PM" src="https://github.com/user-attachments/assets/2a1715f2-4a8d-4f5f-bdc8-d427164c8ec3">|<img width="101" alt="Screenshot 2024-12-06 at 1 44 09 PM" src="https://github.com/user-attachments/assets/3fc78915-b42f-4eab-93e1-5d9e15035e47">
| Dark Disabled |<img width="79" alt="Screenshot 2024-12-06 at 1 49 39 PM" src="https://github.com/user-attachments/assets/f1f21251-2778-4c13-b652-0472c058cd6c">|<img width="85" alt="Screenshot 2024-12-06 at 1 45 38 PM" src="https://github.com/user-attachments/assets/33a88d8a-3348-4af1-8386-a23c3f9d1b72">



See https://chatbot-pr-chatbot-361.surge.sh/patternfly-ai/chatbot/ui#message-bar-with-always-shown-send-button.