### PR TITLE
chore(docs): Add basic nav example

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawerNavigation.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawerNavigation.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { ChatbotDisplayMode } from '@patternfly/chatbot/dist/dynamic/Chatbot';
+import ChatbotConversationHistoryNav, {
+  Conversation
+} from '@patternfly/chatbot/dist/dynamic/ChatbotConversationHistoryNav';
+import { Checkbox } from '@patternfly/react-core';
+
+const initialConversations: Conversation[] = [
+  { id: '1', text: 'Red Hat products and services', noIcon: true },
+  {
+    id: '2',
+    text: 'Enterprise Linux installation and setup',
+    noIcon: true
+  },
+  { id: '3', text: 'Troubleshoot system crash', noIcon: true },
+  { id: '4', text: 'Ansible security and updates', noIcon: true },
+  { id: '5', text: 'Red Hat certification', noIcon: true },
+  { id: '6', text: 'Lightspeed user documentation', noIcon: true },
+  { id: '7', text: 'Crashing pod assistance', noIcon: true },
+  { id: '8', text: 'OpenShift AI pipelines', noIcon: true },
+  { id: '9', text: 'Updating subscription plan', noIcon: true },
+  { id: '10', text: 'Red Hat licensing options', noIcon: true },
+  { id: '11', text: 'RHEL system performance', noIcon: true },
+  { id: '12', text: 'Manage user accounts', noIcon: true }
+];
+
+export const ChatbotHeaderTitleDemo: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [isButtonOrderReversed, setIsbuttonOrderReversed] = React.useState(false);
+  const [conversations, setConversations] = React.useState<Conversation[] | { [key: string]: Conversation[] }>(
+    initialConversations
+  );
+  const displayMode = ChatbotDisplayMode.embedded;
+
+  return (
+    <>
+      <Checkbox
+        label="Display drawer"
+        isChecked={isOpen}
+        onChange={() => {
+          setIsOpen(!isOpen);
+          setConversations(initialConversations);
+        }}
+        id="drawer-visible"
+        name="drawer-visible"
+      />
+      <Checkbox
+        label="Reverse action buttons"
+        isChecked={isButtonOrderReversed}
+        onChange={() => setIsbuttonOrderReversed(!isButtonOrderReversed)}
+        id="drawer-actions-visible"
+        name="drawer-actions-visible"
+      ></Checkbox>
+      <ChatbotConversationHistoryNav
+        displayMode={displayMode}
+        onDrawerToggle={() => setIsOpen(!isOpen)}
+        isDrawerOpen={isOpen}
+        setIsDrawerOpen={setIsOpen}
+        // eslint-disable-next-line no-console
+        onSelectActiveItem={(e, selectedItem) => console.log(`Selected history item with id ${selectedItem}`)}
+        conversations={conversations}
+        reverseButtonOrder={isButtonOrderReversed}
+        drawerContent={<div>Drawer content</div>}
+      />
+    </>
+  );
+};

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
@@ -371,6 +371,14 @@ If you're showing a conversation that is already active, you can set the `active
 
 ```
 
+### Drawer with simple menu
+
+The drawer can also be used to display a list of basic menu items.
+
+```js file="./ChatbotHeaderDrawerNavigation.tsx"
+
+```
+
 ### Terms of use
 
 Based on the [PatternFly modal](/components/modal), this modal adapts to the ChatBot display mode and is meant to display terms and conditions for using a ChatBot in your project. The image in the header can be toggled on or off depending on whether the `image` and `altText` props are provided.

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -21,7 +21,8 @@ import {
   MenuGroup,
   MenuItem,
   MenuContent,
-  MenuItemProps
+  MenuItemProps,
+  MenuProps
 } from '@patternfly/react-core';
 
 import { OutlinedCommentAltIcon } from '@patternfly/react-icons';
@@ -79,6 +80,8 @@ export interface ChatbotConversationHistoryNavProps extends DrawerProps {
   reverseButtonOrder?: boolean;
   /** Custom test id for the drawer actions */
   drawerActionsTestId?: string;
+  /** Additional props applied to menu  */
+  menuProps?: MenuProps;
 }
 
 export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConversationHistoryNavProps> = ({
@@ -97,6 +100,7 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   displayMode,
   reverseButtonOrder = false,
   drawerActionsTestId = 'chatbot-nav-drawer-actions',
+  menuProps,
   ...props
 }: ChatbotConversationHistoryNavProps) => {
   const drawerRef = React.useRef<HTMLDivElement>(null);
@@ -163,7 +167,7 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   // - Consumers should pass an array to <Chatbot> of the list of conversations
   // - Groups could be optional, but items need to be ordered by date
   const menuContent = (
-    <Menu isPlain onSelect={onSelectActiveItem} activeItemId={activeItemId}>
+    <Menu isPlain onSelect={onSelectActiveItem} activeItemId={activeItemId} {...menuProps}>
       <MenuContent>{buildMenu()}</MenuContent>
     </Menu>
   );


### PR DESCRIPTION
Nicole had mentioned that some products may require a more basic navigation look. This example documents that it's possible: https://chatbot-pr-chatbot-397.surge.sh/patternfly-ai/chatbot/ui#drawer-with-simple-menu

I am spreading menuProps onto the menu so they can change the role to navigation, etc. if needed.