### PR TITLE
feat(QuickResponse): Add active and selected states

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
@@ -99,7 +99,7 @@ You can apply a `clickedAriaLabel` and `clickedTooltipContent` once a button is 
 
 ### Messages with quick responses
 
-You can offer convenient, clickable responses to messages in the form of quick actions. Quick actions are [PatternFly labels](/components/label/) in a label group, configured to display up to 5 visible labels.
+You can offer convenient, clickable responses to messages in the form of quick actions. Quick actions are [PatternFly labels](/components/label/) in a label group, configured to display up to 5 visible labels. Only 1 response can be selected at a time.
 
 To add quick actions, pass `quickResponses` to `<Message>`. This can be overridden by passing additional `<LabelGroup>` props to `quickResponseContainerProps`, or additional `<Label>` props to `quickResponses`.
 

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -95,20 +95,6 @@
     display: grid;
     gap: var(--pf-t--global--spacer--sm);
   }
-
-  &-quick-response {
-    .pf-v6-c-label {
-      --pf-v6-c-label--FontSize: var(--pf-t--global--font--size--md);
-
-      @media screen and (min-width: 401px) and (max-width: 600px) {
-        --pf-v6-c-label__text--MaxWidth: 20ch;
-      }
-
-      @media screen and (max-width: 400px) {
-        --pf-v6-c-label__text--MaxWidth: 15ch;
-      }
-    }
-  }
 }
 
 // Attachments

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -6,16 +6,7 @@ import React from 'react';
 
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import {
-  Avatar,
-  AvatarProps,
-  Label,
-  LabelGroup,
-  LabelGroupProps,
-  LabelProps,
-  Timestamp,
-  Truncate
-} from '@patternfly/react-core';
+import { Avatar, AvatarProps, Label, LabelGroupProps, Timestamp, Truncate } from '@patternfly/react-core';
 import MessageLoading from './MessageLoading';
 import CodeBlockMessage from './CodeBlockMessage/CodeBlockMessage';
 import TextMessage from './TextMessage/TextMessage';
@@ -27,12 +18,8 @@ import UnorderedListMessage from './ListMessage/UnorderedListMessage';
 import OrderedListMessage from './ListMessage/OrderedListMessage';
 import QuickStartTile from './QuickStarts/QuickStartTile';
 import { QuickStart, QuickstartAction } from './QuickStarts/types';
+import QuickResponse from './QuickResponse/QuickResponse';
 
-export interface QuickResponse extends Omit<LabelProps, 'children'> {
-  content: string;
-  id: string;
-  onClick: () => void;
-}
 export interface MessageAttachment {
   /** Name of file attached to the message */
   name: string;
@@ -135,6 +122,7 @@ export const Message: React.FunctionComponent<MessageProps> = ({
   // Keep timestamps consistent between Timestamp component and aria-label
   const date = new Date();
   const dateString = timestamp ?? `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+
   return (
     <section
       aria-label={`Message from ${role} - ${dateString}`}
@@ -194,16 +182,10 @@ export const Message: React.FunctionComponent<MessageProps> = ({
             )}
             {!isLoading && actions && <ResponseActions actions={actions} />}
             {!isLoading && quickResponses && (
-              <LabelGroup
-                className={`pf-chatbot__message-quick-response ${quickResponseContainerProps?.className}`}
-                {...quickResponseContainerProps}
-              >
-                {quickResponses.map(({ id, onClick, content, ...props }: QuickResponse) => (
-                  <Label variant="outline" color="blue" key={id} onClick={onClick} {...props}>
-                    {content}
-                  </Label>
-                ))}
-              </LabelGroup>
+              <QuickResponse
+                quickResponses={quickResponses}
+                quickResponseContainerProps={quickResponseContainerProps}
+              />
             )}
           </div>
           {attachments && (

--- a/packages/module/src/Message/QuickResponse/QuickResponse.scss
+++ b/packages/module/src/Message/QuickResponse/QuickResponse.scss
@@ -1,0 +1,33 @@
+.pf-chatbot__message-quick-response {
+  .pf-v6-c-label {
+    --pf-v6-c-label--FontSize: var(--pf-t--global--font--size--md);
+
+    @media screen and (min-width: 401px) and (max-width: 600px) {
+      --pf-v6-c-label__text--MaxWidth: 20ch;
+    }
+
+    @media screen and (max-width: 400px) {
+      --pf-v6-c-label__text--MaxWidth: 15ch;
+    }
+  }
+
+  .pf-chatbot__message-quick-response--selected {
+    .pf-v6-c-label__content:is(:hover, :focus) {
+      --pf-v6-c-label--m-clickable--hover--BorderWidth: 0;
+      --pf-v6-c-label--BackgroundColor: var(--pf-v6-c-label--m-blue--BackgroundColor);
+    }
+  }
+
+  .pf-chatbot__message-quick-response--selected:hover,
+  .pf-chatbot__message-quick-response--selected:focus {
+    --pf-v6-c-label--m-clickable--hover--BorderWidth: 0;
+    --pf-v6-c-label--BackgroundColor: var(--pf-v6-c-label--m-blue--BackgroundColor);
+  }
+
+  // active state right before selection
+  .pf-v6-c-label.pf-m-blue.pf-m-clickable .pf-v6-c-label__content:is(:active) {
+    --pf-v6-c-label--BackgroundColor: var(--pf-v6-c-label--m-blue--BackgroundColor);
+    --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-v6-c-label--m-blue--BackgroundColor);
+    --pf-v6-c-label--m-clickable--hover--BorderWidth: 0;
+  }
+}

--- a/packages/module/src/Message/QuickResponse/QuickResponse.tsx
+++ b/packages/module/src/Message/QuickResponse/QuickResponse.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Label, LabelGroup, LabelGroupProps, LabelProps } from '@patternfly/react-core';
+import { CheckIcon } from '@patternfly/react-icons';
+
+export interface QuickResponse extends Omit<LabelProps, 'children'> {
+  content: string;
+  id: string;
+  onClick: () => void;
+}
+
+export interface QuickResponseProps {
+  /** Props for quick responses */
+  quickResponses: QuickResponse[];
+  /** Props for quick responses container */
+  quickResponseContainerProps?: Omit<LabelGroupProps, 'ref'>;
+}
+
+export const QuickResponse: React.FunctionComponent<QuickResponseProps> = ({
+  quickResponses,
+  quickResponseContainerProps = { numLabels: 5 }
+}: QuickResponseProps) => {
+  const [selectedQuickResponse, setSelectedQuickResponse] = React.useState<string>();
+
+  const handleQuickResponseClick = (id: string, onClick?: () => void) => {
+    setSelectedQuickResponse(id);
+    onClick && onClick();
+  };
+  return (
+    <LabelGroup
+      className={`pf-chatbot__message-quick-response ${quickResponseContainerProps?.className}`}
+      {...quickResponseContainerProps}
+    >
+      {quickResponses.map(({ id, onClick, content, className, ...props }: QuickResponse) => (
+        <Label
+          variant={id === selectedQuickResponse ? undefined : 'outline'}
+          icon={id === selectedQuickResponse ? <CheckIcon /> : undefined}
+          color="blue"
+          key={id}
+          onClick={() => handleQuickResponseClick(id, onClick)}
+          className={`${id === selectedQuickResponse ? 'pf-chatbot__message-quick-response--selected' : ''} ${className ? className : ''}`}
+          {...props}
+        >
+          {content}
+        </Label>
+      ))}
+    </LabelGroup>
+  );
+};
+
+export default QuickResponse;

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -19,6 +19,7 @@
 @import './Message/ListMessage/ListMessage';
 @import './Message/MessageLoading';
 @import './Message/QuickStarts/QuickStartTile';
+@import './Message/QuickResponse/QuickResponse';
 @import './MessageBar/MessageBar';
 @import './MessageBox/MessageBox';
 @import './MessageBox/JumpButton';


### PR DESCRIPTION
Added two additional visual states to quick response labels. Only one option can be selected per block. Unlike the actions (thumbs up/down), selection persists if you click somewhere else.

State | Before | After |
|-|-|-|
|Default|<img width="102" alt="Screenshot 2025-01-09 at 3 33 58 PM" src="https://github.com/user-attachments/assets/0722cee1-d270-43ea-9a3d-3a5d7ef5e24c" />|<img width="98" alt="Screenshot 2025-01-09 at 3 33 21 PM" src="https://github.com/user-attachments/assets/5249bf59-d77b-4383-9b5a-c4f59480b10b" />|
|Hover|<img width="104" alt="Screenshot 2025-01-09 at 3 34 07 PM" src="https://github.com/user-attachments/assets/dc64ce0e-cabd-4f03-b44e-ae612e66daa2" />|<img width="104" alt="Screenshot 2025-01-09 at 3 34 02 PM" src="https://github.com/user-attachments/assets/fdc3b8d5-b46d-4b0a-b3f2-dfa19cafb84f" />|
|Active|<img width="104" alt="Screenshot 2025-01-09 at 3 34 07 PM" src="https://github.com/user-attachments/assets/dc64ce0e-cabd-4f03-b44e-ae612e66daa2" />|<img width="106" alt="Screenshot 2025-01-09 at 3 33 30 PM" src="https://github.com/user-attachments/assets/e4a0b368-20a6-4fe8-b58a-632c3c90a0b8" />
|Selected|<img width="104" alt="Screenshot 2025-01-09 at 3 34 07 PM" src="https://github.com/user-attachments/assets/dc64ce0e-cabd-4f03-b44e-ae612e66daa2" />|<img width="125" alt="Screenshot 2025-01-09 at 3 33 36 PM" src="https://github.com/user-attachments/assets/7d150e87-4812-4af9-b143-449f6e77c47a" />

Click on some buttons here to see them: https://chatbot-pr-chatbot-403.surge.sh/patternfly-ai/chatbot/messages#messages-with-quick-responses
