### PR TITLE
chore(docs): Remove references to Lightspeed

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotFooter.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotFooter.tsx
@@ -8,7 +8,7 @@ export const ChatbotFooterExample: React.FunctionComponent = () => {
   return (
     <ChatbotFooter>
       <MessageBar onSendMessage={handleSend} hasMicrophoneButton hasAttachButton />
-      <ChatbotFootnote label="Lightspeed uses AI. Check for mistakes." />
+      <ChatbotFootnote label="ChatBot uses AI. Check for mistakes." />
     </ChatbotFooter>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotFootnote.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotFootnote.tsx
@@ -3,10 +3,10 @@ import { ChatbotFootnote } from '@patternfly/chatbot/dist/dynamic/ChatbotFooter'
 
 export const FootnoteDemo: React.FunctionComponent = () => (
   <ChatbotFootnote
-    label="Lightspeed uses AI. Check for mistakes."
+    label="ChatBot uses AI. Check for mistakes."
     popover={{
       title: 'Verify accuracy',
-      description: `While Lightspeed strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
+      description: `While ChatBot strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
       bannerImage: {
         src: 'https://cdn.dribbble.com/userupload/10651749/file/original-8a07b8e39d9e8bf002358c66fce1223e.gif',
         alt: 'Example image for footnote popover'

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
@@ -34,10 +34,10 @@ import userAvatar from '../Messages/user_avatar.svg';
 import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 
 const footnoteProps = {
-  label: 'Lightspeed uses AI. Check for mistakes.',
+  label: 'ChatBot uses AI. Check for mistakes.',
   popover: {
     title: 'Verify accuracy',
-    description: `While Lightspeed strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
+    description: `While ChatBot strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
     bannerImage: {
       src: 'https://cdn.dribbble.com/userupload/10651749/file/original-8a07b8e39d9e8bf002358c66fce1223e.gif',
       alt: 'Example image for footnote popover'

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachment.tsx
@@ -244,7 +244,7 @@ export const BasicDemo: React.FunctionComponent = () => {
               </div>
             )}
             <MessageBar onSendMessage={handleSend} hasAttachButton handleAttach={handleAttach} />
-            <ChatbotFootnote label="Lightspeed uses AI. Check for mistakes." />
+            <ChatbotFootnote label="ChatBot uses AI. Check for mistakes." />
           </ChatbotFooter>
         </FileDropZone>
       </Chatbot>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
@@ -259,7 +259,7 @@ export const AttachmentMenuDemo: React.FunctionComponent = () => {
                   onAttachMenuToggleClick: onToggleClick
                 }}
               />
-              <ChatbotFootnote label="Lightspeed uses AI. Check for mistakes." />
+              <ChatbotFootnote label="ChatBot uses AI. Check for mistakes." />
             </ChatbotFooter>
           </>
         </FileDropZone>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedChatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedChatbot.tsx
@@ -42,10 +42,10 @@ import userAvatar from '../Messages/user_avatar.svg';
 import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 
 const footnoteProps = {
-  label: 'Lightspeed uses AI. Check for mistakes.',
+  label: 'ChatBot uses AI. Check for mistakes.',
   popover: {
     title: 'Verify accuracy',
-    description: `While Lightspeed strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
+    description: `While ChatBot strives for accuracy, there's always a possibility of errors. It's a good practice to verify critical information from reliable sources, especially if it's crucial for decision-making or actions.`,
     bannerImage: {
       src: 'https://cdn.dribbble.com/userupload/10651749/file/original-8a07b8e39d9e8bf002358c66fce1223e.gif',
       alt: 'Example image for footnote popover'

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
@@ -11,7 +11,7 @@ describe('ChatbotConversationHistoryNav', () => {
   const initialConversations: Conversation[] = [
     {
       id: '1',
-      text: 'Lightspeed documentation'
+      text: 'ChatBot documentation'
     }
   ];
 
@@ -25,7 +25,7 @@ describe('ChatbotConversationHistoryNav', () => {
         conversations={initialConversations}
       />
     );
-    expect(screen.queryByText('Lightspeed documentation')).toBeInTheDocument();
+    expect(screen.queryByText('ChatBot documentation')).toBeInTheDocument();
   });
 
   it('should display the conversations for grouped conversations', () => {
@@ -120,7 +120,7 @@ describe('ChatbotConversationHistoryNav', () => {
     });
 
     waitFor(() => {
-      expect(screen.queryByText('Lightspeed documentation')).not.toBeInTheDocument();
+      expect(screen.queryByText('ChatBot documentation')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Left the conversation history examples alone, but swapped Lightspeed for ChatBot in the footers, etc.