### PR TITLE
feat(TableMessage): Add support for PatternFly tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@patternfly/react-table": "^6.1.0",
         "dompurify": "^3.2.0",
         "react-dropzone": "^14.2.3"
       },
@@ -3832,7 +3833,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
       "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-core": "^6.1.0",
@@ -17299,8 +17299,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "puppeteer-cluster": "^0.24.0"
   },
   "dependencies": {
+    "@patternfly/react-table": "^6.1.0",
     "dompurify": "^3.2.0",
     "react-dropzone": "^14.2.3"
   },

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -127,13 +127,13 @@ _Italic text, formatted with single underscores_
 
   const inlineCode = `Here is an inline code - \`() => void\``;
 
-  const table = `
+  const table = `To customize your table, you can use [PatternFly TableProps](/components/table#table)
 
- | Version | GA date | Full support end date | Maintenance support end date | User role 
- |-|-|-|-|-|
- | 2.5 | September 30, 2024 | September 30, 2025| September 30, 2025 | Administrator |
- | 2.5 | June 27, 2023 | June 30, 2024 | June 30, 2024 | Editor |
- 
+ | Version | GA date | User role 
+ |-|-|-|
+ | 2.5 | September 30, 2024 | Administrator |
+ | 2.5 | June 27, 2023 | Editor |
+ | 3.0 | April 1, 2025 | Administrator
  `;
 
   return (

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -28,6 +28,8 @@ export const BotMessageExample: React.FunctionComponent = () => {
         return inlineCode;
       case 'link':
         return link;
+      case 'table':
+        return table;
       default:
         return;
     }
@@ -125,6 +127,15 @@ _Italic text, formatted with single underscores_
 
   const inlineCode = `Here is an inline code - \`() => void\``;
 
+  const table = `
+
+ | Version | Release Date |
+ |-|-|
+ | Version 2.5 | Cell 2 |
+ | Version 2.4 | Cell 4 |
+
+ `;
+
   return (
     <>
       <Message name="Bot" role="bot" avatar={patternflyAvatar} content={`Text-based message from a bot named "Bot"`} />
@@ -215,6 +226,13 @@ _Italic text, formatted with single underscores_
             name="bot-message-type"
             label="More complex list"
             id="more-complex-list"
+          />
+          <Radio
+            isChecked={variant === 'table'}
+            onChange={() => setVariant('table')}
+            name="bot-message-type"
+            label="Table"
+            id="table"
           />
         </FormGroup>
       </Form>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -129,11 +129,11 @@ _Italic text, formatted with single underscores_
 
   const table = `
 
- | Version | Release Date |
- |-|-|
- | Version 2.5 | Cell 2 |
- | Version 2.4 | Cell 4 |
-
+ | Version | GA date | Full support end date | Maintenance support end date | User role 
+ |-|-|-|-|-|
+ | 2.5 | September 30, 2024 | September 30, 2025| September 30, 2025 | Administrator |
+ | 2.5 | June 27, 2023 | June 30, 2024 | June 30, 2024 | Editor |
+ 
  `;
 
   return (

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -236,7 +236,15 @@ _Italic text, formatted with single underscores_
           />
         </FormGroup>
       </Form>
-      <Message name="Bot" role="bot" avatar={patternflyAvatar} content={renderContent()} />
+      <Message
+        name="Bot"
+        role="bot"
+        avatar={patternflyAvatar}
+        content={renderContent()}
+        tableProps={
+          variant === 'table' ? { 'aria-label': 'App information and user roles for bot messages' } : undefined
+        }
+      />
     </>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -28,6 +28,8 @@ export const UserMessageExample: React.FunctionComponent = () => {
         return moreComplexList;
       case 'link':
         return link;
+      case 'table':
+        return table;
       default:
         return;
     }
@@ -125,6 +127,15 @@ _Italic text, formatted with single underscores_
 
   const inlineCode = `Here is an inline code - \`() => void\``;
 
+  const table = `
+
+ | Version | GA date | Full support end date | Maintenance support end date | User role 
+ |-|-|-|-|-|
+ | 2.5 | September 30, 2024 | September 30, 2025| September 30, 2025 | Administrator |
+ | 2.5 | June 27, 2023 | June 30, 2024 | June 30, 2024 | Editor |
+ 
+ `;
+
   return (
     <>
       <Message
@@ -205,6 +216,13 @@ _Italic text, formatted with single underscores_
             name="user-message-type"
             label="More complex list"
             id="user-more-complex-list"
+          />
+          <Radio
+            isChecked={variant === 'table'}
+            onChange={() => setVariant('table')}
+            name="user-message-type"
+            label="Table"
+            id="user-table"
           />
         </FormGroup>
       </Form>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -226,7 +226,15 @@ _Italic text, formatted with single underscores_
           />
         </FormGroup>
       </Form>
-      <Message name="User" role="user" content={renderContent()} avatar={userAvatar} />
+      <Message
+        name="User"
+        role="user"
+        content={renderContent()}
+        avatar={userAvatar}
+        tableProps={
+          variant === 'table' ? { 'aria-label': 'App information and user roles for user messages' } : undefined
+        }
+      />
     </>
   );
 };

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -127,13 +127,13 @@ _Italic text, formatted with single underscores_
 
   const inlineCode = `Here is an inline code - \`() => void\``;
 
-  const table = `
+  const table = `To customize your table, you can use [PatternFly TableProps](/components/table#table)
 
- | Version | GA date | Full support end date | Maintenance support end date | User role 
- |-|-|-|-|-|
- | 2.5 | September 30, 2024 | September 30, 2025| September 30, 2025 | Administrator |
- | 2.5 | June 27, 2023 | June 30, 2024 | June 30, 2024 | Editor |
- 
+ | Version | GA date | User role 
+ |-|-|-|
+ | 2.5 | September 30, 2024 | Administrator |
+ | 2.5 | June 27, 2023 | Editor |
+ | 3.0 | April 1, 2025 | Administrator
  `;
 
   return (

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -88,6 +88,55 @@ const HEADING = `
 const BLOCK_QUOTES = `> Blockquotes can also be nested...
 >> ...by using additional greater-than signs (>) right next to each other...
 > > > ...or with spaces between each sign.`;
+const TABLE = `
+
+ | Column 1 | Column 2 |
+ |-|-|
+ | Cell 1 | Cell 2 |
+ | Cell 3 | Cell 4 |
+
+ `;
+
+const ONE_COLUMN_TABLE = `
+
+ | Column 1 |
+ |-|
+ | Cell 1 | 
+ | Cell 2 |
+
+ `;
+
+const ONE_CELL_TABLE = `
+
+ | Column 1 |
+ |-|
+ | Cell 1 | 
+
+ `;
+
+const HEADERLESS_TABLE = `
+
+ | |
+ |-|
+ | Cell 1 | 
+
+ `;
+
+const CHILDLESS_TABLE = `
+
+ | Column 1 |
+ |-|
+ | | 
+
+ `;
+
+const EMPTY_TABLE = `
+
+ | |
+ |-|
+ | | 
+
+ `;
 
 const checkListItemsRendered = () => {
   const items = ['Item 1', 'Item 2', 'Item 3'];
@@ -527,5 +576,79 @@ describe('Message', () => {
     expect(screen.getByRole('heading', { name: /h4 Heading/i })).toBeTruthy();
     expect(screen.getByRole('heading', { name: /h5 Heading/i })).toBeTruthy();
     expect(screen.getByRole('heading', { name: /h6 Heading/i })).toBeTruthy();
+  });
+  it('should render table correctly', () => {
+    render(<Message avatar="./img" role="user" name="User" content={TABLE} />);
+    expect(screen.getByRole('row', { name: /Column 1 Column 2/i })).toBeTruthy();
+    expect(screen.getByRole('row', { name: /Cell 1 Cell 2/i })).toBeTruthy();
+    expect(screen.getByRole('row', { name: /Cell 3 Cell 4/i })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: /Column 1/i })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: /Column 2/i })).toBeTruthy();
+    expect(screen.getByRole('cell', { name: /Cell 1/i })).toBeTruthy();
+    expect(screen.getByRole('cell', { name: /Cell 2/i })).toBeTruthy();
+    expect(screen.getByRole('cell', { name: /Cell 3/i })).toBeTruthy();
+    expect(screen.getByRole('cell', { name: /Cell 4/i })).toBeTruthy();
+  });
+  it('should render table data labels correctly for mobile breakpoint', () => {
+    render(<Message avatar="./img" role="user" name="User" content={TABLE} />);
+    expect(screen.getByRole('row', { name: /Cell 1 Cell 2/i })).toHaveAttribute('extraHeaders', 'Column 1,Column 2');
+    expect(screen.getByRole('row', { name: /Cell 3 Cell 4/i })).toHaveAttribute('extraHeaders', 'Column 1,Column 2');
+    expect(screen.getByRole('cell', { name: /Cell 1/i })).toHaveAttribute('data-label', 'Column 1');
+    expect(screen.getByRole('cell', { name: /Cell 2/i })).toHaveAttribute('data-label', 'Column 2');
+    expect(screen.getByRole('cell', { name: /Cell 3/i })).toHaveAttribute('data-label', 'Column 1');
+    expect(screen.getByRole('cell', { name: /Cell 4/i })).toHaveAttribute('data-label', 'Column 2');
+  });
+  it('should render table data labels correctly for mobile breakpoint for one column table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={ONE_COLUMN_TABLE} />);
+    expect(screen.getByRole('row', { name: /Cell 1/i })).toHaveAttribute('extraHeaders', 'Column 1');
+    expect(screen.getByRole('row', { name: /Cell 2/i })).toHaveAttribute('extraHeaders', 'Column 1');
+    expect(screen.getByRole('cell', { name: /Cell 1/i })).toHaveAttribute('data-label', 'Column 1');
+    expect(screen.getByRole('cell', { name: /Cell 2/i })).toHaveAttribute('data-label', 'Column 1');
+  });
+  it('should render table data labels correctly for mobile breakpoint for one cell table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={ONE_CELL_TABLE} />);
+    expect(screen.getByRole('row', { name: /Cell 1/i })).toHaveAttribute('extraHeaders', 'Column 1');
+    expect(screen.getByRole('cell', { name: /Cell 1/i })).toHaveAttribute('data-label', 'Column 1');
+  });
+  it('should render table data labels correctly for mobile breakpoint for headerless', () => {
+    render(<Message avatar="./img" role="user" name="User" content={HEADERLESS_TABLE} />);
+    expect(screen.getByRole('row', { name: /Cell 1/i })).toHaveAttribute('extraHeaders', '');
+    expect(screen.getByRole('cell', { name: /Cell 1/i })).not.toHaveAttribute('data-label');
+  });
+  it('should render table data labels correctly for mobile breakpoint for childless', () => {
+    render(<Message avatar="./img" role="user" name="User" content={CHILDLESS_TABLE} />);
+    expect(screen.getByRole('cell')).not.toHaveAttribute('extraHeaders', 'Column 1');
+  });
+  it('should render table data labels correctly for mobile breakpoint for empty', () => {
+    render(<Message avatar="./img" role="user" name="User" content={EMPTY_TABLE} />);
+    expect(screen.getByRole('cell')).not.toHaveAttribute('extraHeaders', '');
+  });
+  it('should render table aria label correctly for long table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing Column 1 and Column 2/i })).toBeTruthy();
+  });
+  it('should render table aria label correctly for one column table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={ONE_COLUMN_TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
+  });
+  it('should render table aria label correctly for one cell table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={ONE_CELL_TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
+  });
+  it('should render table aria label correctly for headerless table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={HEADERLESS_TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing some data/i })).toBeTruthy();
+  });
+  it('should render table aria label correctly for empty table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={EMPTY_TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing some data/i })).toBeTruthy();
+  });
+  it('should render table aria label correctly for childless table', () => {
+    render(<Message avatar="./img" role="user" name="User" content={CHILDLESS_TABLE} />);
+    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
+  });
+  it('should render custom table aria label correctly', () => {
+    render(<Message avatar="./img" role="user" name="User" content={TABLE} tableProps={{ 'aria-label': 'Test' }} />);
+    expect(screen.getByRole('grid', { name: /Test/i })).toBeTruthy();
   });
 });

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -623,30 +623,6 @@ describe('Message', () => {
     render(<Message avatar="./img" role="user" name="User" content={EMPTY_TABLE} />);
     expect(screen.getByRole('cell')).not.toHaveAttribute('extraHeaders', '');
   });
-  it('should render table aria label correctly for long table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing Column 1 and Column 2/i })).toBeTruthy();
-  });
-  it('should render table aria label correctly for one column table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={ONE_COLUMN_TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
-  });
-  it('should render table aria label correctly for one cell table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={ONE_CELL_TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
-  });
-  it('should render table aria label correctly for headerless table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={HEADERLESS_TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing some data/i })).toBeTruthy();
-  });
-  it('should render table aria label correctly for empty table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={EMPTY_TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing some data/i })).toBeTruthy();
-  });
-  it('should render table aria label correctly for childless table', () => {
-    render(<Message avatar="./img" role="user" name="User" content={CHILDLESS_TABLE} />);
-    expect(screen.getByRole('grid', { name: /Table describing Column 1/i })).toBeTruthy();
-  });
   it('should render custom table aria label correctly', () => {
     render(<Message avatar="./img" role="user" name="User" content={TABLE} tableProps={{ 'aria-label': 'Test' }} />);
     expect(screen.getByRole('grid', { name: /Test/i })).toBeTruthy();

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -29,6 +29,12 @@ import { QuickStart, QuickstartAction } from './QuickStarts/types';
 import QuickResponse from './QuickResponse/QuickResponse';
 import UserFeedback, { UserFeedbackProps } from './UserFeedback/UserFeedback';
 import UserFeedbackComplete, { UserFeedbackCompleteProps } from './UserFeedback/UserFeedbackComplete';
+import TableMessage from './TableMessage/TableMessage';
+import TrMessage from './TableMessage/TrMessage';
+import TdMessage from './TableMessage/TdMessage';
+import TbodyMessage from './TableMessage/TbodyMessage';
+import TheadMessage from './TableMessage/TheadMessage';
+import ThMessage from './TableMessage/ThMessage';
 
 export interface MessageAttachment {
   /** Name of file attached to the message */
@@ -109,6 +115,10 @@ export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'rol
   isLiveRegion?: boolean;
   /** Ref applied to message  */
   innerRef?: React.Ref<HTMLDivElement>;
+  tableProps?: {
+    'aria-label'?: string;
+    className?: string;
+  };
 }
 
 export const MessageBase: React.FunctionComponent<MessageProps> = ({
@@ -133,6 +143,7 @@ export const MessageBase: React.FunctionComponent<MessageProps> = ({
   userFeedbackComplete,
   isLiveRegion = true,
   innerRef,
+  tableProps,
   ...props
 }: MessageProps) => {
   let avatarClassName;
@@ -187,16 +198,27 @@ export const MessageBase: React.FunctionComponent<MessageProps> = ({
                       {children}
                     </CodeBlockMessage>
                   ),
-                  ul: UnorderedListMessage,
-                  ol: (props) => <OrderedListMessage {...props} />,
-                  li: ListItemMessage,
                   h1: (props) => <TextMessage component={ContentVariants.h1} {...props} />,
                   h2: (props) => <TextMessage component={ContentVariants.h2} {...props} />,
                   h3: (props) => <TextMessage component={ContentVariants.h3} {...props} />,
                   h4: (props) => <TextMessage component={ContentVariants.h4} {...props} />,
                   h5: (props) => <TextMessage component={ContentVariants.h5} {...props} />,
                   h6: (props) => <TextMessage component={ContentVariants.h6} {...props} />,
-                  blockquote: (props) => <TextMessage component={ContentVariants.blockquote} {...props} />
+                  blockquote: (props) => <TextMessage component={ContentVariants.blockquote} {...props} />,
+                  ul: (props) => <UnorderedListMessage {...props} />,
+                  ol: (props) => <OrderedListMessage {...props} />,
+                  li: (props) => <ListItemMessage {...props} />,
+                  table: (props) => <TableMessage {...props} {...tableProps} />,
+                  tbody: (props) => <TbodyMessage {...props} />,
+                  thead: (props) => <TheadMessage {...props} />,
+                  tr: (props) => <TrMessage {...props} />,
+                  td: (props) => {
+                    // Conflicts with Td type
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { width, ...rest } = props;
+                    return <TdMessage {...rest} />;
+                  },
+                  th: (props) => <ThMessage {...props} />
                 }}
                 remarkPlugins={[remarkGfm]}
               >

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -35,6 +35,7 @@ import TdMessage from './TableMessage/TdMessage';
 import TbodyMessage from './TableMessage/TbodyMessage';
 import TheadMessage from './TableMessage/TheadMessage';
 import ThMessage from './TableMessage/ThMessage';
+import { TableProps } from '@patternfly/react-table';
 
 export interface MessageAttachment {
   /** Name of file attached to the message */
@@ -115,10 +116,7 @@ export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'rol
   isLiveRegion?: boolean;
   /** Ref applied to message  */
   innerRef?: React.Ref<HTMLDivElement>;
-  tableProps?: {
-    'aria-label'?: string;
-    className?: string;
-  };
+  tableProps?: TableProps;
 }
 
 export const MessageBase: React.FunctionComponent<MessageProps> = ({

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -116,7 +116,8 @@ export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'rol
   isLiveRegion?: boolean;
   /** Ref applied to message  */
   innerRef?: React.Ref<HTMLDivElement>;
-  tableProps?: TableProps;
+  /** Props for table message. It is important to include a detailed aria-label that describes the purpose of the table. */
+  tableProps?: Required<Pick<TableProps, 'aria-label'>> & TableProps;
 }
 
 export const MessageBase: React.FunctionComponent<MessageProps> = ({

--- a/packages/module/src/Message/TableMessage/TableMessage.scss
+++ b/packages/module/src/Message/TableMessage/TableMessage.scss
@@ -1,0 +1,23 @@
+.pf-chatbot__message-table {
+  border-radius: var(--pf-t--global--border--radius--small);
+  --pf-v6-c-table--BackgroundColor: var(--pf-t--global--background--color--tertiary--default);
+  --pf-v6-c-table--BorderColor: var(--pf-t--global--border--color--default);
+  padding: 0 var(--pf-t--global--spacer--lg) 0 var(--pf-t--global--spacer--lg);
+
+  &.pf-m-grid.pf-v6-c-table tbody:where(.pf-v6-c-table__tbody):first-of-type {
+    border-block-start: 0;
+  }
+
+  tbody {
+    border-radius: var(--pf-t--global--border--radius--small);
+  }
+
+  tr {
+    --pf-v6-c-table__tr--responsive--PaddingInlineEnd: 0;
+    --pf-v6-c-table__tr--responsive--PaddingInlineStart: 0;
+  }
+
+  .pf-v6-c-table__tr:last-of-type {
+    border-block-end: 0;
+  }
+}

--- a/packages/module/src/Message/TableMessage/TableMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TableMessage.tsx
@@ -1,0 +1,89 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Table, TableProps } from '@patternfly/react-table';
+
+interface Properties {
+  line: number;
+  column: number;
+  offset: number;
+}
+export interface TableNode {
+  children?: TableNode[];
+  value?: string;
+  position: { start: Properties; end: Properties };
+  tagName: string;
+  type: string;
+}
+
+const TableMessage = ({ children, ...props }: TableProps & ExtraProps) => {
+  const { className, ...rest } = props;
+
+  // This allows us to parse the nested data we get back from the 3rd party Markdown parser
+  // Open to feedback here if there is a better way to do this
+  // This looks for ths and spits them all out so we can filter them later, looking for text values
+  const findHeaders = (array?: TableNode[]) => {
+    const headers: TableNode[] = [];
+    if (!array) {
+      return headers;
+    }
+    const traverse = (items: TableNode[]) => {
+      for (const item of items) {
+        if (item.tagName === 'th') {
+          headers.push(item);
+        }
+        if (item.children) {
+          traverse(item.children);
+        }
+      }
+    };
+
+    traverse(array);
+    return headers;
+  };
+
+  const headers = findHeaders(rest.node?.children as TableNode[] | undefined);
+  const headerTextValues = headers.map((header) => header?.children?.filter((c) => c?.type === 'text')[0]?.value);
+
+  // We are sending these header text values down to child tds by passing them through children, since mobile view for tables expects a dataLabel prop
+  // The data structure does not otherwise know this information at that level
+  // This is somewhat opinionated and may break if 3rd party library changes
+  // See Tr and Tbody for other usage
+  const modifyChildren = (children) =>
+    React.Children.map(children, (child) => {
+      if (child && headerTextValues?.length > 0) {
+        return React.cloneElement(child, { extraHeaders: headerTextValues });
+      }
+      return child;
+    });
+
+  const generateAriaLabel = (arr: (string | undefined)[]) => {
+    const labels = arr.filter((item) => typeof item !== 'undefined');
+    if (labels.length === 0) {
+      return 'Table describing some data';
+    }
+    if (labels.length === 1) {
+      return `Table describing ${labels[0]}`;
+    }
+    const firstValues = labels.slice(0, labels.length - 1);
+    const lastValue = labels[labels.length - 1];
+    return `Table describing ${firstValues.join(', ') + ' and ' + lastValue}`;
+  };
+
+  return (
+    // gridBreakPoint is so we show mobile-styled-PF table
+    <Table
+      aria-label={props['aria-label'] ?? generateAriaLabel(headerTextValues)}
+      gridBreakPoint="grid"
+      className={`pf-chatbot__message-table ${className ? className : ''}`}
+      {...rest}
+    >
+      {modifyChildren(children)}
+    </Table>
+  );
+};
+
+export default TableMessage;

--- a/packages/module/src/Message/TableMessage/TableMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TableMessage.tsx
@@ -60,23 +60,17 @@ const TableMessage = ({ children, ...props }: TableProps & ExtraProps) => {
       return child;
     });
 
-  const generateAriaLabel = (arr: (string | undefined)[]) => {
-    const labels = arr.filter((item) => typeof item !== 'undefined');
-    if (labels.length === 0) {
-      return 'Table describing some data';
-    }
-    if (labels.length === 1) {
-      return `Table describing ${labels[0]}`;
-    }
-    const firstValues = labels.slice(0, labels.length - 1);
-    const lastValue = labels[labels.length - 1];
-    return `Table describing ${firstValues.join(', ') + ' and ' + lastValue}`;
-  };
+  if (!props['aria-label']) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'For accessibility reasons an aria-label should be specified for the Table via the <Message /> tableProps prop'
+    );
+  }
 
   return (
     // gridBreakPoint is so we show mobile-styled-PF table
     <Table
-      aria-label={props['aria-label'] ?? generateAriaLabel(headerTextValues)}
+      aria-label={props['aria-label']}
       gridBreakPoint="grid"
       className={`pf-chatbot__message-table ${className ? className : ''}`}
       {...rest}

--- a/packages/module/src/Message/TableMessage/TbodyMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TbodyMessage.tsx
@@ -1,0 +1,20 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Tbody, TbodyProps } from '@patternfly/react-table';
+
+const TbodyProps = ({ children, ...props }: TbodyProps & ExtraProps & { extraHeaders?: string[] }) => {
+  // passthrough so we can place dataLabel on tds
+  const modifyChildren = (children) => {
+    if (children && props.extraHeaders) {
+      return React.Children.map(children, (child) => React.cloneElement(child, { extraHeaders: props.extraHeaders }));
+    }
+    return children;
+  };
+
+  return <Tbody {...props}>{modifyChildren(children)}</Tbody>;
+};
+export default TbodyProps;

--- a/packages/module/src/Message/TableMessage/TdMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TdMessage.tsx
@@ -1,0 +1,11 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Td, TdProps } from '@patternfly/react-table';
+
+const TdMessage = ({ children, ...props }: TdProps & ExtraProps) => <Td {...props}>{children}</Td>;
+
+export default TdMessage;

--- a/packages/module/src/Message/TableMessage/ThMessage.tsx
+++ b/packages/module/src/Message/TableMessage/ThMessage.tsx
@@ -1,0 +1,11 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Th, ThProps } from '@patternfly/react-table';
+
+const ThMessage = ({ children, ...props }: ThProps & ExtraProps) => <Th {...props}>{children}</Th>;
+
+export default ThMessage;

--- a/packages/module/src/Message/TableMessage/TheadMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TheadMessage.tsx
@@ -1,0 +1,11 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Thead, TheadProps } from '@patternfly/react-table';
+
+const TheadMessage = ({ children, ...props }: TheadProps & ExtraProps) => <Thead {...props}>{children}</Thead>;
+
+export default TheadMessage;

--- a/packages/module/src/Message/TableMessage/TrMessage.tsx
+++ b/packages/module/src/Message/TableMessage/TrMessage.tsx
@@ -1,0 +1,27 @@
+// ============================================================================
+// Chatbot Main - Message - Content - Table
+// ============================================================================
+
+import React from 'react';
+import { ExtraProps } from 'react-markdown';
+import { Tr, TrProps } from '@patternfly/react-table';
+
+const TrMessage = ({ children, ...props }: TrProps & ExtraProps & { extraHeaders?: string[] }) => {
+  let tdIndex = 0;
+
+  // passthrough so we can place dataLabel on tds
+  // places column name on correct child
+  const modifyChildren = (children) =>
+    React.Children.map(children, (child) => {
+      if (child.type.name === 'td' && props.extraHeaders) {
+        const clonedChild = React.cloneElement(child, { dataLabel: props.extraHeaders[tdIndex] });
+        tdIndex = tdIndex + 1;
+        return clonedChild;
+      }
+      return child;
+    });
+
+  return <Tr {...props}>{modifyChildren(children)}</Tr>;
+};
+
+export default TrMessage;

--- a/packages/module/src/Message/TextMessage/TextMessage.scss
+++ b/packages/module/src/Message/TextMessage/TextMessage.scss
@@ -10,6 +10,11 @@
   }
 }
 
+// make it full width when there's a table, so the table can grow as needed
+.pf-chatbot__message-and-actions:has(.pf-chatbot__message-table) {
+  width: 100%;
+}
+
 // Need to inline shorter text
 .pf-chatbot__message-text {
   width: fit-content;

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -18,6 +18,7 @@
 @import './Message/CodeBlockMessage/CodeBlockMessage';
 @import './Message/TextMessage/TextMessage';
 @import './Message/ListMessage/ListMessage';
+@import './Message/TableMessage/TableMessage';
 @import './Message/MessageLoading';
 @import './Message/QuickStarts/QuickStartTile';
 @import './Message/QuickResponse/QuickResponse';


### PR DESCRIPTION
Wire Message to re-route tables to PF tables.

These are just basic tables, with no bells and whistles. I am defaulting to the mobile breakpoint, but we could also do a regular table at certain widths. Let me know what you want to do here - I am just copying Figma right now. I am also letting this be full width, but it will resize down if you change the device viewport or screen size - let me know if that's not what we want.

<img width="861" alt="Screenshot 2025-02-03 at 6 50 38 PM" src="https://github.com/user-attachments/assets/f65825bb-22b0-4f74-8264-f055caa12bab" />

I am defining a default aria label, allowing passage of aria-labels, and also attempting to generate these based on headers. I have written tests for full tables, blank tables, headerless tables, cell-less tables, 1 column-tables, and 1-cell tables. Let me know if you can break this and we'll add another test.

**Doc changes:**
* https://chatbot-pr-chatbot-425.surge.sh/patternfly-ai/chatbot/messages#bot-messages 
* https://chatbot-pr-chatbot-425.surge.sh/patternfly-ai/chatbot/messages/#user-messages