### PR TITLE
fix(AttachButton): Hide input from screenreaders

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotMessageBarAttach.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotMessageBarAttach.tsx
@@ -126,7 +126,7 @@ export const ChatbotMessageBarDefaultAttachExample: React.FunctionComponent = ()
   return (
     <>
       {/* this is required for react-dropzone to work in Safari and Firefox */}
-      <input {...getInputProps()} />
+      <input {...getInputProps()} hidden />
       <MessageBar
         onSendMessage={handleSend}
         attachMenuProps={{

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
@@ -209,7 +209,7 @@ export const AttachmentMenuDemo: React.FunctionComponent = () => {
   return (
     <>
       {/* this is required for react-dropzone to work in Safari and Firefox */}
-      <input {...getInputProps()} />
+      <input {...getInputProps()} hidden />
       <ChatbotToggle
         tooltipLabel="Chatbot"
         isChatbotVisible={chatbotVisible}

--- a/packages/module/src/MessageBar/AttachButton.tsx
+++ b/packages/module/src/MessageBar/AttachButton.tsx
@@ -46,7 +46,7 @@ const AttachButtonBase: React.FunctionComponent<AttachButtonProps> = ({
   return (
     <>
       {/* this is required for react-dropzone to work in Safari and Firefox */}
-      <input data-testid={inputTestId} {...getInputProps()} />
+      <input data-testid={inputTestId} {...getInputProps()} hidden />
       <Tooltip
         id="pf-chatbot__tooltip--attach"
         content={tooltipContent}


### PR DESCRIPTION
Saw this in scrum - we're using this too, so pulling it in.

There is a required input for react-dropzone. We should hide it from screenreaders since it's not something users can interact with.

See https://github.com/patternfly/patternfly-react/pull/11438.