### PR TITLE
fix(MessageBar): Fix to handle enter key when send button initially disabled

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.tsx
+++ b/packages/module/src/MessageBar/MessageBar.tsx
@@ -111,17 +111,14 @@ export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
 
   // Handle sending message
   const handleSend = React.useCallback(() => {
-    setMessage((m) => {
-      onSendMessage(m);
-      setMessage('');
-      if (textareaRef.current) {
-        textareaRef.current.innerText = '';
-        setShowPlaceholder(true);
-        textareaRef.current.blur();
-      }
-      return '';
-    });
-  }, [onSendMessage]);
+    onSendMessage(message);
+    if (textareaRef.current) {
+      textareaRef.current.innerText = '';
+      setShowPlaceholder(true);
+      textareaRef.current.blur();
+    }
+    setMessage('');
+  }, [onSendMessage, message]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
@@ -132,7 +129,7 @@ export const MessageBar: React.FunctionComponent<MessageBarProps> = ({
         }
       }
     },
-    [handleSend]
+    [handleSend, isSendButtonDisabled, handleStopButton]
   );
 
   const handleAttachMenuToggle = () => {


### PR DESCRIPTION
Fixes #429 

Adds dependencies to the `handleKeyDown` callback so that it recognizes changes to the enablement of the send and stop buttons.

Also fixes an issue with a console error message for updating the MessageBar while already updating.