### PR TITLE
fix(QuickStarts/ResponseActions): CSS updates

### DIFF
--- a/packages/module/src/Message/QuickStarts/QuickStartTile.scss
+++ b/packages/module/src/Message/QuickStarts/QuickStartTile.scss
@@ -1,5 +1,4 @@
 .pf-chatbot__quickstarts-tile {
-  min-width: 360px;
   max-width: 650px;
   width: 100%;
 

--- a/packages/module/src/ResponseActions/ResponseActions.scss
+++ b/packages/module/src/ResponseActions/ResponseActions.scss
@@ -3,7 +3,7 @@
   gap: var(--pf-t--global--spacer--xs);
   grid-template-columns: repeat(auto-fit, minmax(0, max-content));
 
-  .pf-v6-c-button {
+  .pf-chatbot__button--response-action.pf-v6-c-button.pf-m-plain.pf-m-small {
     --pf-v6-c-button__icon--Color: var(--pf-t--global--icon--color--subtle);
     border-radius: var(--pf-t--global--border--radius--pill);
     width: 2.3125rem;
@@ -22,7 +22,7 @@
   }
 }
 
-.pf-v6-c-button.pf-chatbot__button--response-action-clicked {
+.pf-v6-c-button.pf-chatbot__button--response-action-clicked.pf-v6-c-button.pf-m-plain.pf-m-small {
   --pf-v6-c-button--m-plain--BackgroundColor: var(--pf-t--global--background--color--action--plain--alt--clicked);
   --pf-v6-c-button__icon--Color: var(--pf-t--global--icon--color--regular);
 }


### PR DESCRIPTION
Drop min-width on QuickStartTile so it performs well in drawers, etc. and added better targeting to response actions. This is following testing the chatbot in a resizable drawer layout.