### PR TITLE
feat(ChatbotConversationHistoryNav): Add loading state and error state

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawer.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawer.tsx
@@ -32,12 +32,16 @@ const initialConversations: { [key: string]: Conversation[] } = {
 };
 
 const ERROR = {
-  bodyText:
-    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  bodyText: (
+    <>
+      To try again, check your connection and reload this page. If the issue persists,{' '}
+      <a href="">contact the support team</a>.
+    </>
+  ),
   buttonText: 'Reload',
   buttonIcon: <Spinner size="sm" />,
   hasButton: true,
-  titleText: 'Failed to load',
+  titleText: 'Could not load chat history',
   status: EmptyStateStatus.danger,
   onClick: () => alert('Clicked Reload')
 };

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawer.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderDrawer.tsx
@@ -3,7 +3,7 @@ import { ChatbotDisplayMode } from '@patternfly/chatbot/dist/dynamic/Chatbot';
 import ChatbotConversationHistoryNav, {
   Conversation
 } from '@patternfly/chatbot/dist/dynamic/ChatbotConversationHistoryNav';
-import { Checkbox } from '@patternfly/react-core';
+import { Checkbox, EmptyStateStatus, Spinner } from '@patternfly/react-core';
 
 const initialConversations: { [key: string]: Conversation[] } = {
   Today: [{ id: '1', text: 'Red Hat products and services' }],
@@ -31,12 +31,25 @@ const initialConversations: { [key: string]: Conversation[] } = {
   ]
 };
 
+const ERROR = {
+  bodyText:
+    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  buttonText: 'Reload',
+  buttonIcon: <Spinner size="sm" />,
+  hasButton: true,
+  titleText: 'Failed to load',
+  status: EmptyStateStatus.danger,
+  onClick: () => alert('Clicked Reload')
+};
+
 export const ChatbotHeaderTitleDemo: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(true);
   const [isButtonOrderReversed, setIsButtonOrderReversed] = React.useState(false);
   const [conversations, setConversations] = React.useState<Conversation[] | { [key: string]: Conversation[] }>(
     initialConversations
   );
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [hasError, setHasError] = React.useState(false);
   const displayMode = ChatbotDisplayMode.embedded;
 
   const findMatchingItems = (targetValue: string) => {
@@ -74,6 +87,20 @@ export const ChatbotHeaderTitleDemo: React.FunctionComponent = () => {
         id="drawer-actions-visible"
         name="drawer-actions-visible"
       ></Checkbox>
+      <Checkbox
+        label="Show loading state"
+        isChecked={isLoading}
+        onChange={() => setIsLoading(!isLoading)}
+        id="drawer-is-loading"
+        name="drawer-is-loading"
+      ></Checkbox>
+      <Checkbox
+        label="Show error state"
+        isChecked={hasError}
+        onChange={() => setHasError(!hasError)}
+        id="drawer-has-error"
+        name="drawer-has-error"
+      ></Checkbox>
       <ChatbotConversationHistoryNav
         displayMode={displayMode}
         onDrawerToggle={() => setIsOpen(!isOpen)}
@@ -96,6 +123,8 @@ export const ChatbotHeaderTitleDemo: React.FunctionComponent = () => {
           setConversations(newConversations);
         }}
         drawerContent={<div>Drawer content</div>}
+        isLoading={isLoading}
+        errorState={hasError ? ERROR : undefined}
       />
     </>
   );

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
@@ -189,3 +189,17 @@
     }
   }
 }
+
+.pf-chatbot__history-loading {
+  display: flex;
+  padding: var(--pf-t--global--spacer--lg);
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--lg);
+}
+
+.pf-chatbot__history-loading-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--sm);
+  align-self: stretch;
+}

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
@@ -277,7 +277,7 @@ describe('ChatbotConversationHistoryNav', () => {
         isLoading
       />
     );
-    expect(screen.getByRole('dialog', { name: /Loading/i })).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: /Loading chatbot conversation history/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
   });
 
@@ -292,7 +292,7 @@ describe('ChatbotConversationHistoryNav', () => {
         handleTextInputChange={jest.fn()}
         conversations={initialConversations}
         isLoading
-        loadingState={{ 'aria-label': 'I am a test' }}
+        loadingState={{ screenreaderText: 'I am a test' }}
       />
     );
     expect(screen.getByRole('dialog', { name: /I am a test/i })).toBeTruthy();

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
@@ -7,23 +7,31 @@ import ChatbotConversationHistoryNav, { Conversation } from './ChatbotConversati
 import { EmptyStateStatus, Spinner } from '@patternfly/react-core';
 
 const ERROR = {
-  bodyText:
-    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  bodyText: (
+    <>
+      To try again, check your connection and reload this page. If the issue persists,{' '}
+      <a href="">contact the support team</a>.
+    </>
+  ),
   buttonText: 'Reload',
   buttonIcon: <Spinner size="sm" />,
   hasButton: true,
-  titleText: 'Failed to load',
+  titleText: 'Could not load chat history',
   status: EmptyStateStatus.danger,
   onClick: () => alert('Clicked Reload')
 };
 
 const ERROR_WITHOUT_BUTTON = {
-  bodyText:
-    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  bodyText: (
+    <>
+      To try again, check your connection and reload this page. If the issue persists,{' '}
+      <a href="">contact the support team</a>.
+    </>
+  ),
   buttonText: 'Reload',
   buttonIcon: <Spinner size="sm" />,
   hasButton: false,
-  titleText: 'Failed to load',
+  titleText: 'Could not load chat history',
   status: EmptyStateStatus.danger,
   onClick: () => alert('Clicked Reload')
 };
@@ -305,13 +313,13 @@ describe('ChatbotConversationHistoryNav', () => {
     );
     expect(
       screen.getByRole('dialog', {
-        name: /Failed to load Something went wrong while loading your chat history. Please check your connection and try again or refresh this page. Loading... Reload/i
+        name: /Could not load chat history To try again, check your connection and reload this page. If the issue persists, contact the support team . Loading... Reload/i
       })
     ).toBeTruthy();
     expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /Loading... Reload/i })).toBeTruthy();
     expect(screen.getByRole('textbox', { name: /Filter menu items/i })).toBeTruthy();
-    expect(screen.getByRole('heading', { name: /Failed to load/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Could not load chat history/i })).toBeTruthy();
   });
 
   it('should accept errorState without button', () => {
@@ -329,13 +337,13 @@ describe('ChatbotConversationHistoryNav', () => {
     );
     expect(
       screen.getByRole('dialog', {
-        name: /Failed to load Something went wrong while loading your chat history. Please check your connection and try again or refresh this page./i
+        name: /Could not load chat history To try again, check your connection and reload this page. If the issue persists, contact the support team ./i
       })
     ).toBeTruthy();
     expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Loading... Reload/i })).toBeFalsy();
     expect(screen.getByRole('textbox', { name: /Filter menu items/i })).toBeTruthy();
-    expect(screen.getByRole('heading', { name: /Failed to load/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Could not load chat history/i })).toBeTruthy();
   });
 
   it('should show loading state over error state if both are supplied', () => {

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.test.tsx
@@ -4,6 +4,29 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { ChatbotDisplayMode } from '../Chatbot/Chatbot';
 import ChatbotConversationHistoryNav, { Conversation } from './ChatbotConversationHistoryNav';
+import { EmptyStateStatus, Spinner } from '@patternfly/react-core';
+
+const ERROR = {
+  bodyText:
+    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  buttonText: 'Reload',
+  buttonIcon: <Spinner size="sm" />,
+  hasButton: true,
+  titleText: 'Failed to load',
+  status: EmptyStateStatus.danger,
+  onClick: () => alert('Clicked Reload')
+};
+
+const ERROR_WITHOUT_BUTTON = {
+  bodyText:
+    'Something went wrong while loading your chat history. Please check your connection and try again or refresh this page.',
+  buttonText: 'Reload',
+  buttonIcon: <Spinner size="sm" />,
+  hasButton: false,
+  titleText: 'Failed to load',
+  status: EmptyStateStatus.danger,
+  onClick: () => alert('Clicked Reload')
+};
 
 describe('ChatbotConversationHistoryNav', () => {
   const onDrawerToggle = jest.fn();
@@ -231,5 +254,104 @@ describe('ChatbotConversationHistoryNav', () => {
     );
     const element = container.querySelector('.test');
     expect(element).toBeInTheDocument();
+  });
+
+  it('should show loading state if triggered', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+        isLoading
+      />
+    );
+    expect(screen.getByRole('dialog', { name: /Loading/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
+  });
+
+  it('should pass alternative aria label to loading state', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+        isLoading
+        loadingState={{ 'aria-label': 'I am a test' }}
+      />
+    );
+    expect(screen.getByRole('dialog', { name: /I am a test/i })).toBeTruthy();
+  });
+
+  it('should accept errorState', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+        errorState={ERROR}
+      />
+    );
+    expect(
+      screen.getByRole('dialog', {
+        name: /Failed to load Something went wrong while loading your chat history. Please check your connection and try again or refresh this page. Loading... Reload/i
+      })
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Loading... Reload/i })).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: /Filter menu items/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Failed to load/i })).toBeTruthy();
+  });
+
+  it('should accept errorState without button', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+        errorState={ERROR_WITHOUT_BUTTON}
+      />
+    );
+    expect(
+      screen.getByRole('dialog', {
+        name: /Failed to load Something went wrong while loading your chat history. Please check your connection and try again or refresh this page./i
+      })
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Close drawer panel/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Loading... Reload/i })).toBeFalsy();
+    expect(screen.getByRole('textbox', { name: /Filter menu items/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Failed to load/i })).toBeTruthy();
+  });
+
+  it('should show loading state over error state if both are supplied', () => {
+    render(
+      <ChatbotConversationHistoryNav
+        onDrawerToggle={onDrawerToggle}
+        isDrawerOpen={true}
+        displayMode={ChatbotDisplayMode.fullscreen}
+        setIsDrawerOpen={jest.fn()}
+        reverseButtonOrder={false}
+        handleTextInputChange={jest.fn()}
+        conversations={initialConversations}
+        isLoading
+        errorState={ERROR}
+      />
+    );
+    expect(screen.getByRole('dialog', { name: /Loading/i })).toBeTruthy();
   });
 });

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -29,7 +29,8 @@ import {
   DrawerHeadProps,
   DrawerActionsProps,
   DrawerCloseButtonProps,
-  DrawerPanelBodyProps
+  DrawerPanelBodyProps,
+  SkeletonProps
 } from '@patternfly/react-core';
 
 import { OutlinedCommentAltIcon } from '@patternfly/react-icons';
@@ -108,7 +109,7 @@ export interface ChatbotConversationHistoryNavProps extends DrawerProps {
   /** Whether to show drawer loading state */
   isLoading?: boolean;
   /** Additional props for loading state */
-  loadingState?: { 'aria-label': string };
+  loadingState?: SkeletonProps;
   /** Content to show in error state. Error state will appear once content is passed in. */
   errorState?: HistoryEmptyStateProps;
 }

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -35,6 +35,8 @@ import {
 import { OutlinedCommentAltIcon } from '@patternfly/react-icons';
 import { ChatbotDisplayMode } from '../Chatbot/Chatbot';
 import ConversationHistoryDropdown from './ChatbotConversationHistoryDropdown';
+import LoadingState from './LoadingState';
+import HistoryEmptyState, { HistoryEmptyStateProps } from './EmptyState';
 
 export interface Conversation {
   /** Conversation id */
@@ -103,6 +105,12 @@ export interface ChatbotConversationHistoryNavProps extends DrawerProps {
   drawerCloseButtonProps?: DrawerCloseButtonProps;
   /** Additional props appleid to drawer panel body */
   drawerPanelBodyProps?: DrawerPanelBodyProps;
+  /** Whether to show drawer loading state */
+  isLoading?: boolean;
+  /** Additional props for loading state */
+  loadingState?: { 'aria-label': string };
+  /** Content to show in error state. Error state will appear once content is passed in. */
+  errorState?: HistoryEmptyStateProps;
 }
 
 export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConversationHistoryNavProps> = ({
@@ -129,6 +137,9 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   drawerActionsProps,
   drawerCloseButtonProps,
   drawerPanelBodyProps,
+  isLoading,
+  loadingState,
+  errorState,
   ...props
 }: ChatbotConversationHistoryNavProps) => {
   const drawerRef = React.useRef<HTMLDivElement>(null);
@@ -194,24 +205,19 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
   // Menu Content
   // - Consumers should pass an array to <Chatbot> of the list of conversations
   // - Groups could be optional, but items need to be ordered by date
-  const menuContent = (
-    <Menu isPlain onSelect={onSelectActiveItem} activeItemId={activeItemId} {...menuProps}>
-      <MenuContent>{buildMenu()}</MenuContent>
-    </Menu>
-  );
+  const renderMenuContent = () => {
+    if (errorState) {
+      return <HistoryEmptyState {...errorState} />;
+    }
+    return (
+      <Menu isPlain onSelect={onSelectActiveItem} activeItemId={activeItemId} {...menuProps}>
+        <MenuContent>{buildMenu()}</MenuContent>
+      </Menu>
+    );
+  };
 
-  const panelContent = (
-    <DrawerPanelContent focusTrap={{ enabled: true }} defaultSize="384px" {...drawerPanelContentProps}>
-      <DrawerHead {...drawerHeadProps}>
-        <DrawerActions
-          data-testid={drawerActionsTestId}
-          className={reverseButtonOrder ? 'pf-v6-c-drawer__actions--reversed' : ''}
-          {...drawerActionsProps}
-        >
-          <DrawerCloseButton onClick={onDrawerToggle} {...drawerCloseButtonProps} />
-          {onNewChat && <Button onClick={onNewChat}>{newChatButtonText}</Button>}
-        </DrawerActions>
-      </DrawerHead>
+  const renderDrawerContent = () => (
+    <>
       {handleTextInputChange && (
         <div className="pf-chatbot__input">
           <SearchInput
@@ -221,9 +227,37 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
           />
         </div>
       )}
-      <DrawerPanelBody {...drawerPanelBodyProps}>{menuContent}</DrawerPanelBody>
-    </DrawerPanelContent>
+      <DrawerPanelBody {...drawerPanelBodyProps}>{renderMenuContent()}</DrawerPanelBody>
+    </>
   );
+
+  const renderPanelContent = () => {
+    const drawer = (
+      <>
+        <DrawerHead {...drawerHeadProps}>
+          <DrawerActions
+            data-testid={drawerActionsTestId}
+            className={reverseButtonOrder ? 'pf-v6-c-drawer__actions--reversed' : ''}
+            {...drawerActionsProps}
+          >
+            <DrawerCloseButton onClick={onDrawerToggle} {...drawerCloseButtonProps} />
+            {onNewChat && <Button onClick={onNewChat}>{newChatButtonText}</Button>}
+          </DrawerActions>
+        </DrawerHead>
+        {isLoading ? <LoadingState {...loadingState} /> : renderDrawerContent()}
+      </>
+    );
+    return (
+      <DrawerPanelContent
+        aria-live="polite"
+        focusTrap={{ enabled: true }}
+        defaultSize="384px"
+        {...drawerPanelContentProps}
+      >
+        {drawer}
+      </DrawerPanelContent>
+    );
+  };
 
   // An onKeyDown property must be passed to the Drawer component to handle closing
   // the drawer panel and deactivating the focus trap via the Escape key.
@@ -246,7 +280,7 @@ export const ChatbotConversationHistoryNav: React.FunctionComponent<ChatbotConve
       isInline={displayMode === ChatbotDisplayMode.fullscreen || displayMode === ChatbotDisplayMode.embedded}
       {...props}
     >
-      <DrawerContent panelContent={panelContent} {...drawerContentProps}>
+      <DrawerContent panelContent={renderPanelContent()} {...drawerContentProps}>
         <DrawerContentBody {...drawerContentBodyProps}>
           <>
             <div

--- a/packages/module/src/ChatbotConversationHistoryNav/EmptyState.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/EmptyState.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 export interface HistoryEmptyStateProps extends EmptyStateProps {
   onClick?: () => void;
-  bodyText?: string;
+  bodyText?: string | React.ReactNode;
   buttonText?: string;
   buttonIcon?: React.ReactNode;
   hasButton?: boolean;

--- a/packages/module/src/ChatbotConversationHistoryNav/EmptyState.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/EmptyState.tsx
@@ -1,0 +1,44 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateProps
+} from '@patternfly/react-core';
+import React from 'react';
+
+export interface HistoryEmptyStateProps extends EmptyStateProps {
+  onClick?: () => void;
+  bodyText?: string;
+  buttonText?: string;
+  buttonIcon?: React.ReactNode;
+  hasButton?: boolean;
+}
+
+export const HistoryEmptyState: React.FunctionComponent<HistoryEmptyStateProps> = ({
+  bodyText,
+  buttonIcon,
+  buttonText,
+  status,
+  titleText,
+  headingLevel,
+  onClick,
+  hasButton = false,
+  ...props
+}: HistoryEmptyStateProps) => (
+  <EmptyState status={status} titleText={titleText} headingLevel={headingLevel} {...props}>
+    <EmptyStateBody>{bodyText}</EmptyStateBody>
+    {hasButton && (
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button icon={buttonIcon} variant="secondary" onClick={onClick}>
+            {buttonText}
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    )}
+  </EmptyState>
+);
+
+export default HistoryEmptyState;

--- a/packages/module/src/ChatbotConversationHistoryNav/LoadingState.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/LoadingState.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@patternfly/react-core';
+import React from 'react';
+
+export interface LoadingStateProps {
+  'aria-label'?: string;
+}
+export const LoadingState: React.FunctionComponent<LoadingStateProps> = ({
+  'aria-label': ariaLabel
+}: LoadingStateProps) => (
+  <div className="pf-chatbot__history-loading">
+    <div className="pf-chatbot__history-loading-block">
+      <Skeleton screenreaderText={ariaLabel ?? 'Loading'} fontSize="3xl" />
+    </div>
+    <div className="pf-chatbot__history-loading-block">
+      <Skeleton fontSize="sm" width="70%" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+    </div>
+    <div className="pf-chatbot__history-loading-block">
+      <Skeleton fontSize="sm" width="70%" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+    </div>
+    <div className="pf-chatbot__history-loading-block">
+      <Skeleton fontSize="sm" width="70%" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="3xl" />
+    </div>
+    <div className="pf-chatbot__history-loading-block">
+      <Skeleton fontSize="sm" width="70%" />
+      <Skeleton fontSize="3xl" />
+    </div>
+  </div>
+);
+
+export default LoadingState;

--- a/packages/module/src/ChatbotConversationHistoryNav/LoadingState.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/LoadingState.tsx
@@ -1,37 +1,36 @@
-import { Skeleton } from '@patternfly/react-core';
+import { Skeleton, SkeletonProps } from '@patternfly/react-core';
 import React from 'react';
 
-export interface LoadingStateProps {
-  'aria-label'?: string;
-}
-export const LoadingState: React.FunctionComponent<LoadingStateProps> = ({
-  'aria-label': ariaLabel
-}: LoadingStateProps) => (
+export const LoadingState: React.FunctionComponent<SkeletonProps> = ({ screenreaderText, ...rest }: SkeletonProps) => (
   <div className="pf-chatbot__history-loading">
     <div className="pf-chatbot__history-loading-block">
-      <Skeleton screenreaderText={ariaLabel ?? 'Loading'} fontSize="3xl" />
+      <Skeleton
+        screenreaderText={screenreaderText ?? 'Loading chatbot conversation history'}
+        fontSize="3xl"
+        {...rest}
+      />
     </div>
     <div className="pf-chatbot__history-loading-block">
-      <Skeleton fontSize="sm" width="70%" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="sm" width="70%" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
     </div>
     <div className="pf-chatbot__history-loading-block">
-      <Skeleton fontSize="sm" width="70%" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="sm" width="70%" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
     </div>
     <div className="pf-chatbot__history-loading-block">
-      <Skeleton fontSize="sm" width="70%" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
-      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="sm" width="70%" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
     </div>
     <div className="pf-chatbot__history-loading-block">
-      <Skeleton fontSize="sm" width="70%" />
-      <Skeleton fontSize="3xl" />
+      <Skeleton fontSize="sm" width="70%" {...rest} />
+      <Skeleton fontSize="3xl" {...rest} />
     </div>
   </div>
 );


### PR DESCRIPTION
Add skeleton loading state that can be controlled via isLoading prop on drawer. Error state is controlled via the errorState prop.

I made the history panel and aria-live region so it will announce updates, but unsure if that's super annoying. Would love to get Eric's opinion on this.

Docs change: https://chatbot-pr-chatbot-445.surge.sh/patternfly-ai/chatbot/ui#drawer-with-search-and-new-chat-button