### PR TITLE
fix(MessageBar): Add additional specificity to input bar

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -68,13 +68,13 @@
   .pf-v6-c-form-control__textarea:focus-visible {
     outline: none;
   }
-  textarea {
+  .pf-v6-c-form-control > textarea {
     outline-offset: 0px;
     --pf-v6-c-form-control--PaddingBlockStart: 0;
     --pf-v6-c-form-control--PaddingBlockEnd: 0;
     --pf-v6-c-form-control--BorderRadius: 0;
   }
-  textarea:focus-visible {
+  .pf-v6-c-form-control > textarea:focus-visible {
     outline: none;
   }
 }


### PR DESCRIPTION
Input bar works in Ansible, allegedly. ShadowBot team was noticing that the specificity needed to be a little higher. This should get them where they need to be.