### PR TITLE
fix(MessageBar): Allow passing props to button tooltip

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.tsx
+++ b/packages/module/src/MessageBar/MessageBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonProps, DropEvent, TextArea, TextAreaProps } from '@patternfly/react-core';
+import { ButtonProps, DropEvent, TextArea, TextAreaProps, TooltipProps } from '@patternfly/react-core';
 
 // Import Chatbot components
 import SendButton from './SendButton';
@@ -53,13 +53,19 @@ export interface MessageBarProps extends TextAreaProps {
   isSendButtonDisabled?: boolean;
   /** Prop to allow passage of additional props to buttons */
   buttonProps?: {
-    attach?: { tooltipContent?: string; props?: ButtonProps; inputTestId?: string };
-    stop?: { tooltipContent?: string; props?: ButtonProps };
-    send?: { tooltipContent?: string; props?: ButtonProps };
+    attach?: {
+      tooltipContent?: string;
+      props?: ButtonProps;
+      inputTestId?: string;
+      tooltipProps?: Omit<TooltipProps, 'content'>;
+    };
+    stop?: { tooltipContent?: string; props?: ButtonProps; tooltipProps?: Omit<TooltipProps, 'content'> };
+    send?: { tooltipContent?: string; props?: ButtonProps; tooltipProps?: Omit<TooltipProps, 'content'> };
     microphone?: {
       tooltipContent?: { active?: string; inactive?: string };
       language?: string;
       props?: ButtonProps;
+      tooltipProps?: Omit<TooltipProps, 'content'>;
     };
   };
   /** A callback for when the text area value changes. */

--- a/packages/module/src/MessageBar/MicrophoneButton.tsx
+++ b/packages/module/src/MessageBar/MicrophoneButton.tsx
@@ -19,7 +19,7 @@ export interface MicrophoneButtonProps extends ButtonProps {
   /** Callback to update the message value once speech recognition is complete */
   onSpeechRecognition: React.Dispatch<React.SetStateAction<string>>;
   /** Props to control the PF Tooltip component */
-  tooltipProps?: TooltipProps;
+  tooltipProps?: Omit<TooltipProps, 'content'>;
   /** English text "Use microphone" and "Stop listening" used in the tooltip */
   tooltipContent?: { active?: string; inactive?: string };
   /** Locale code for language speech recognition is conducted in. This should be in the format 'en-US', a.k.a. the ISO 639-1 code, a dash, and the ISO_3166-1 code. */


### PR DESCRIPTION
We want to allow for manual configuration of tooltips by consumers - this allows passage of props.