### PR TITLE
fix(MessageBar): Make resize and form-control overrides more important

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -50,9 +50,9 @@
 }
 
 .pf-chatbot__message-textarea {
-  --pf-v6-c-form-control--before--BorderStyle: none;
-  --pf-v6-c-form-control--after--BorderStyle: none;
-  resize: none;
+  --pf-v6-c-form-control--before--BorderStyle: none !important;
+  --pf-v6-c-form-control--after--BorderStyle: none !important;
+  resize: none !important;
   background-color: transparent;
   font-size: var(--pf-t--global--font--size--md);
   line-height: 1.5rem;


### PR DESCRIPTION
ShadowBox extension team is using vite. Styles are getting pulled in wrong order, with PF first. This means that these styles are being overridden in their implementation. This will hopefully fix their issue.