### PR TITLE
fix(SourcesCard): Add explicit links style

### DIFF
--- a/packages/module/src/SourcesCard/SourcesCard.scss
+++ b/packages/module/src/SourcesCard/SourcesCard.scss
@@ -4,6 +4,12 @@
   gap: var(--pf-t--global--spacer--sm);
   padding-block-start: var(--pf-t--global--spacer--sm);
   max-width: 22.5rem;
+
+  a {
+    color: var(--pf-t--global--text--color--link--default) !important;
+    -webkit-text-decoration: var(--pf-t--global--text-decoration--link--line--default) !important;
+    text-decoration: var(--pf-t--global--text-decoration--link--line--default) !important;
+  }
 }
 
 .pf-chatbot__sources-card {


### PR DESCRIPTION
Backstage is not handling link colors appropriately - explicitly define these.