### PR TITLE
fix(Styles): Allow for graceful failure when styles pulled in wrong order

### DIFF
--- a/packages/module/src/ChatbotModal/ChatbotModal.scss
+++ b/packages/module/src/ChatbotModal/ChatbotModal.scss
@@ -1,15 +1,15 @@
 .pf-chatbot__chatbot-modal-backdrop {
-  position: static;
+  position: static !important;
 }
 
 .pf-chatbot__chatbot-modal {
-  --pf-v6-c-modal-box--BorderRadius: var(--pf-t--global--border--radius--medium);
-  position: fixed;
+  --pf-v6-c-modal-box--BorderRadius: var(--pf-t--global--border--radius--medium) !important;
+  position: fixed !important;
   inset-block-end: var(--pf-t--global--spacer--800); // no associated semantic token
   inset-inline-end: var(--pf-t--global--spacer--lg);
-  width: 30rem;
+  width: 30rem !important;
   height: 70vh;
-  background-color: var(--pf-t--global--background--color--secondary--default);
+  background-color: var(--pf-t--global--background--color--secondary--default) !important;
 
   .pf-v6-c-modal-box__title {
     --pf-v6-c-modal-box__title--FontSize: var(--pf-t--global--font--size--heading--h3);
@@ -47,8 +47,8 @@
   .pf-chatbot__chatbot-modal--fullscreen {
     inset-block-end: 0;
     inset-inline-end: 0;
-    width: 50%;
-    height: fit-content;
+    width: 50% !important;
+    height: fit-content !important;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -59,7 +59,7 @@
 // Chatbot Display Mode - Default
 // ============================================================================
 .pf-chatbot__chatbot-modal--default {
-  box-shadow: unset;
+  box-shadow: unset !important;
 }
 
 // ============================================================================
@@ -69,9 +69,9 @@
   height: 100vh;
   inset-block-end: 0;
   inset-inline-end: 0;
-  border-radius: 0;
-  --pf-v6-c-modal-box--MaxHeight: 100vh;
-  box-shadow: unset;
+  border-radius: 0 !important;
+  --pf-v6-c-modal-box--MaxHeight: 100vh !important;
+  box-shadow: unset !important;
 }
 
 // ============================================================================

--- a/packages/module/src/CodeModal/CodeModal.scss
+++ b/packages/module/src/CodeModal/CodeModal.scss
@@ -1,12 +1,12 @@
 .pf-chatbot__code-modal {
   .pf-v6-c-code-editor {
-    --pf-v6-c-code-editor__main--BackgroundColor: #1f1f1f;
+    --pf-v6-c-code-editor__main--BackgroundColor: #1f1f1f !important;
     --pf-v6-c-code-editor__main--BorderEndStartRadius: 0;
     --pf-v6-c-code-editor__main--BorderEndEndRadius: 0;
     --pf-v6-c-code-editor__tab--BorderStartEndRadius: var(--pf-t--global--border--radius--small);
   }
   .pf-v6-c-code-editor__header {
-    background: #1f1f1f;
+    background: #1f1f1f !important;
     /** this is for the attachment editor header */
     border-start-start-radius: var(--pf-t--global--border--radius--small);
     border-start-end-radius: var(--pf-t--global--border--radius--small);
@@ -24,7 +24,9 @@
   .pf-v6-c-code-editor__header-content {
     --pf-v6-c-code-editor__header-content--BackgroundColor: #1f1f1f;
     --pf-v6-c-code-editor__header-content--m-plain--BackgroundColor: #1f1f1f;
-    --pf-v6-c-code-editor__header-content--BorderStartStartRadius: var(--pf-t--global--border--radius--small);
+    --pf-v6-c-code-editor__header-content--BorderStartStartRadius: var(
+      --pf-t--global--border--radius--small
+    ) !important;
     --pf-v6-c-code-editor__header-content--PaddingInlineEnd: 0;
     justify-content: flex-end;
   }
@@ -80,5 +82,5 @@
 }
 
 .pf-chatbot__code-modal--fullscreen {
-  height: inherit; // override shared modal so code editor works in full screen
+  height: inherit !important; // override shared modal so code editor works in full screen
 }

--- a/packages/module/src/CodeModal/CodeModal.scss
+++ b/packages/module/src/CodeModal/CodeModal.scss
@@ -1,9 +1,10 @@
 .pf-chatbot__code-modal {
   .pf-v6-c-code-editor {
-    --pf-v6-c-code-editor__main--BackgroundColor: #1f1f1f !important;
+    --pf-v6-c-code-editor__main--BackgroundColor: #1f1f1f;
     --pf-v6-c-code-editor__main--BorderEndStartRadius: 0;
     --pf-v6-c-code-editor__main--BorderEndEndRadius: 0;
     --pf-v6-c-code-editor__tab--BorderStartEndRadius: var(--pf-t--global--border--radius--small);
+    --pf-v6-c-code-editor--m-read-only__main--BackgroundColor: #1f1f1f;
   }
   .pf-v6-c-code-editor__header {
     background: #1f1f1f !important;

--- a/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
+++ b/packages/module/src/FileDetailsLabel/FileDetailsLabel.scss
@@ -7,10 +7,10 @@
 
 .pf-chatbot__file-label {
   padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--sm)
-    var(--pf-t--global--spacer--md);
+    var(--pf-t--global--spacer--md) !important;
   gap: var(--pf-t--global--spacer--sm);
   --pf-v6-c-label--m-clickable--hover--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
-  --pf-v6-c-label--MaxWidth: 12rem;
+  --pf-v6-c-label--MaxWidth: 12rem !important;
   .pf-v6-c-truncate {
     max-width: 9ch;
   }

--- a/packages/module/src/Message/QuickResponse/QuickResponse.tsx
+++ b/packages/module/src/Message/QuickResponse/QuickResponse.tsx
@@ -31,7 +31,7 @@ export const QuickResponse: React.FunctionComponent<QuickResponseProps> = ({
   };
   return (
     <LabelGroup
-      className={`pf-chatbot__message-quick-response ${quickResponseContainerProps?.className}`}
+      className={`pf-chatbot__message-quick-response ${quickResponseContainerProps?.className ? quickResponseContainerProps?.className : ''}`}
       {...quickResponseContainerProps}
     >
       {quickResponses.map(({ id, onClick, content, className, ...props }: QuickResponse) => (

--- a/packages/module/src/Message/TableMessage/TableMessage.scss
+++ b/packages/module/src/Message/TableMessage/TableMessage.scss
@@ -1,7 +1,7 @@
 .pf-chatbot__message-table {
   border-radius: var(--pf-t--global--border--radius--small);
-  --pf-v6-c-table--BackgroundColor: var(--pf-t--global--background--color--tertiary--default);
-  --pf-v6-c-table--BorderColor: var(--pf-t--global--border--color--default);
+  --pf-v6-c-table--BackgroundColor: var(--pf-t--global--background--color--tertiary--default) !important;
+  --pf-v6-c-table--BorderColor: var(--pf-t--global--border--color--default) !important;
   padding: 0 var(--pf-t--global--spacer--lg) 0 var(--pf-t--global--spacer--lg);
 
   &.pf-m-grid.pf-v6-c-table tbody:where(.pf-v6-c-table__tbody):first-of-type {

--- a/packages/module/src/Message/UserFeedback/UserFeedback.scss
+++ b/packages/module/src/Message/UserFeedback/UserFeedback.scss
@@ -45,7 +45,7 @@
 }
 
 .pf-chatbot__feedback-card-form {
-  --pf-v6-c-form__group--m-action--MarginBlockStart: 0;
+  --pf-v6-c-form__group--m-action--MarginBlockStart: 0 !important;
 }
 
 .pf-chatbot__feedback-card-optional {

--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -53,13 +53,13 @@
   --pf-v6-c-form-control--before--BorderStyle: none !important;
   --pf-v6-c-form-control--after--BorderStyle: none !important;
   resize: none !important;
-  background-color: transparent;
-  font-size: var(--pf-t--global--font--size--md);
-  line-height: 1.5rem;
+  background-color: transparent !important;
+  font-size: var(--pf-t--global--font--size--md) !important;
+  line-height: 1.5rem !important;
   max-height: 12rem;
-  overflow-y: auto;
+  overflow-y: auto !important;
   outline: none;
-  overflow-wrap: break-word;
+  overflow-wrap: break-word !important;
   word-wrap: break-word;
   height: 100%;
   width: 100%;
@@ -73,6 +73,7 @@
     --pf-v6-c-form-control--PaddingBlockStart: 0;
     --pf-v6-c-form-control--PaddingBlockEnd: 0;
     --pf-v6-c-form-control--BorderRadius: 0;
+    border-radius: calc(var(--pf-t--global--border--radius--medium) * 2) !important;
   }
   textarea:focus-visible {
     outline: none;

--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -73,7 +73,6 @@
     --pf-v6-c-form-control--PaddingBlockStart: 0;
     --pf-v6-c-form-control--PaddingBlockEnd: 0;
     --pf-v6-c-form-control--BorderRadius: 0;
-    border-radius: calc(var(--pf-t--global--border--radius--medium) * 2) !important;
   }
   textarea:focus-visible {
     outline: none;

--- a/packages/module/src/SourceDetailsMenuItem/SourceDetailsMenuItem.scss
+++ b/packages/module/src/SourceDetailsMenuItem/SourceDetailsMenuItem.scss
@@ -10,7 +10,7 @@
 }
 
 .pf-chatbot__source-details-icon {
-  width: 100%;
+  width: 100% !important;
 }
 
 // this is only used in demo code

--- a/packages/module/src/SourcesCard/SourcesCard.scss
+++ b/packages/module/src/SourcesCard/SourcesCard.scss
@@ -29,7 +29,7 @@
 .pf-chatbot__sources-card-footer-container {
   border-top: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
   padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--sm)
-    var(--pf-t--global--spacer--sm);
+    var(--pf-t--global--spacer--sm) !important;
   .pf-chatbot__sources-card-footer {
     display: flex;
     justify-content: space-between;

--- a/packages/module/src/TermsOfUse/TermsOfUse.scss
+++ b/packages/module/src/TermsOfUse/TermsOfUse.scss
@@ -52,7 +52,7 @@
 .pf-chatbot__chatbot-modal.pf-chatbot__chatbot-modal--fullscreen.pf-chatbot__terms-of-use-modal.pf-chatbot__terms-of-use-modal--fullscreen,
 .pf-chatbot__chatbot-modal.pf-chatbot__chatbot-modal--embedded.pf-chatbot__terms-of-use-modal.pf-chatbot__terms-of-use-modal--embedded {
   // override parent modal style
-  height: inherit;
+  height: inherit !important;
 
   .pf-v6-c-content {
     h2 {


### PR DESCRIPTION
Some consumers have less control over style order. This was causing problems when PatternFly overrode ChatBot overrides. This should allow these consumers to continue using ChatBot with a good level of success.