### PR TITLE
Allow to tune down the logging on console.

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Analytics/Analytics.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Analytics/Analytics.md
@@ -40,6 +40,7 @@ Note that user code only interacts with:
 
 ```nolive
 const initProps: InitProps = {
+  verbose: false,
   segmentKey: 'TODO-key', // TODO add your key here
 //  segmentCdn: 'https://my.org/cdn',  // Set up segment cdn (optional)
 //  segmentIntegrations: { // Provide Segment integrations (optional)
@@ -56,6 +57,8 @@ const initProps: InitProps = {
   console: 'true' // Console provider
 };
 ```
+
+Note, that there is also a key `verbose` that allows you to enable debugging output on web-browser console. By default, this is set to `false`.
 
 1. Once this is done, you can create an instance of the `trackingAPI` and start sending events.
 

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
@@ -98,6 +98,7 @@ export default MessageLoading;
 const date = new Date();
 
 const initProps: InitProps = {
+  verbose: false,
   segmentKey: 'TODO-key', // TODO add your key here
   posthogKey: 'TODO-key',
   umamiKey: 'TODO-key',

--- a/packages/module/src/tracking/console_tracking_provider.ts
+++ b/packages/module/src/tracking/console_tracking_provider.ts
@@ -2,26 +2,35 @@ import { TrackingSpi } from './tracking_spi';
 import { TrackingApi, TrackingEventProperties } from './tracking_api';
 
 export class ConsoleTrackingProvider implements TrackingSpi, TrackingApi {
+  private verbose = false;
   trackPageView(url: string | undefined) {
-    // eslint-disable-next-line no-console
-    console.log('ConsoleProvider pageView', url);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('ConsoleProvider pageView ', url);
+    }
   }
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   registerProvider(): void {}
 
   initialize(): void {
-    // eslint-disable-next-line no-console
-    console.log('ConsoleProvider initialize');
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('ConsoleProvider initialize');
+    }
   }
 
   identify(userID: string): void {
-    // eslint-disable-next-line no-console
-    console.log('ConsoleProvider identify', userID);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('ConsoleProvider identify ', userID);
+    }
   }
 
   trackSingleItem(item: string, properties?: TrackingEventProperties): void {
-    // eslint-disable-next-line no-console
-    console.log('ConsoleProvider: ' + item, properties);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('ConsoleProvider: ' + item, properties);
+    }
   }
 
   getKey(): string {

--- a/packages/module/src/tracking/posthog_tracking_provider.ts
+++ b/packages/module/src/tracking/posthog_tracking_provider.ts
@@ -4,13 +4,16 @@ import { TrackingApi, TrackingEventProperties } from './tracking_api';
 import { InitProps, TrackingSpi } from './tracking_spi';
 
 export class PosthogTrackingProvider implements TrackingSpi, TrackingApi {
+  private verbose = false;
   getKey(): string {
     return 'posthogKey';
   }
 
   initialize(props: InitProps): void {
-    // eslint-disable-next-line no-console
-    console.log('PosthogProvider initialize');
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('PosthogProvider initialize');
+    }
     const posthogKey = props.posthogKey as string;
 
     posthog.init(posthogKey, {
@@ -22,21 +25,27 @@ export class PosthogTrackingProvider implements TrackingSpi, TrackingApi {
   }
 
   identify(userID: string): void {
-    // eslint-disable-next-line no-console
-    console.log('PosthogProvider userID: ' + userID);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('PosthogProvider userID: ' + userID);
+    }
     posthog.identify(userID);
   }
 
   trackPageView(url: string | undefined): void {
-    // eslint-disable-next-line no-console
-    console.log('PostHogProvider url', url);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('PostHogProvider url', url);
+    }
     // TODO posthog seems to record that automatically.
     //  How to not clash with this here? Just leave as no-op?
   }
 
   trackSingleItem(item: string, properties?: TrackingEventProperties): void {
-    // eslint-disable-next-line no-console
-    console.log('PosthogProvider: trackSingleItem' + item, properties);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('PosthogProvider: trackSingleItem' + item, properties);
+    }
     posthog.capture(item, { properties });
   }
 }

--- a/packages/module/src/tracking/segment_tracking_provider.ts
+++ b/packages/module/src/tracking/segment_tracking_provider.ts
@@ -5,13 +5,16 @@ import { InitProps, TrackingSpi } from './tracking_spi';
 
 export class SegmentTrackingProvider implements TrackingSpi, TrackingApi {
   private analytics: AnalyticsBrowser | undefined;
+  private verbose = false;
   getKey(): string {
     return 'segmentKey';
   }
 
   initialize(props: InitProps): void {
-    // eslint-disable-next-line no-console
-    console.log('SegmentProvider initialize');
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('SegmentProvider initialize');
+    }
     const segmentKey = props.segmentKey as string;
 
     // We need to create an object here, as ts lint is unhappy otherwise
@@ -33,16 +36,20 @@ export class SegmentTrackingProvider implements TrackingSpi, TrackingApi {
   }
 
   identify(userID: string): void {
-    // eslint-disable-next-line no-console
-    console.log('SegmentProvider userID: ' + userID);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('SegmentProvider userID: ' + userID);
+    }
     if (this.analytics) {
       this.analytics.identify(userID);
     }
   }
 
   trackPageView(url: string | undefined): void {
-    // eslint-disable-next-line no-console
-    console.log('SegmentProvider url', url);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('SegmentProvider url', url);
+    }
     if (this.analytics) {
       if (url) {
         this.analytics.page(url);
@@ -53,8 +60,10 @@ export class SegmentTrackingProvider implements TrackingSpi, TrackingApi {
   }
 
   trackSingleItem(item: string, properties?: TrackingEventProperties): void {
-    // eslint-disable-next-line no-console
-    console.log('SegmentProvider: trackSingleItem' + item, properties);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('SegmentProvider: trackSingleItem' + item, properties);
+    }
     if (this.analytics) {
       this.analytics.track(item, { properties });
     }

--- a/packages/module/src/tracking/tracking_spi.ts
+++ b/packages/module/src/tracking/tracking_spi.ts
@@ -1,8 +1,12 @@
 import { TrackingApi, TrackingEventProperties } from './tracking_api';
 
-export interface InitProps {
-  [key: string]: string | number | boolean;
+interface BaseProps {
+  verbose: boolean;
 }
+
+export type InitProps = {
+  [key: string]: string | number | boolean;
+} & BaseProps;
 
 export interface TrackingSpi extends TrackingApi {
   // Return a key in InitProps to check if the provided should be enabled

--- a/packages/module/src/tracking/umami_tracking_provider.ts
+++ b/packages/module/src/tracking/umami_tracking_provider.ts
@@ -9,13 +9,17 @@ declare global {
 }
 
 export class UmamiTrackingProvider implements TrackingSpi, TrackingApi {
+  private verbose = false;
   getKey(): string {
     return 'umamiKey';
   }
 
   initialize(props: InitProps): void {
-    // eslint-disable-next-line no-console
-    console.log('UmamiProvider initialize');
+    this.verbose = props.verbose;
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('UmamiProvider initialize');
+    }
     const umamiKey = props.umamiKey as string;
     const hostUrl = props.umamiHostUrl as string;
 
@@ -35,20 +39,26 @@ export class UmamiTrackingProvider implements TrackingSpi, TrackingApi {
   }
 
   identify(userID: string): void {
-    // eslint-disable-next-line no-console
-    console.log('UmamiProvider userID: ' + userID);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('UmamiProvider userID: ' + userID);
+    }
     window.umami?.identify({ userID });
   }
 
   trackPageView(url: string | undefined): void {
-    // eslint-disable-next-line no-console
-    console.log('UmamiProvider url', url);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('UmamiProvider url', url);
+    }
     window.umami?.track({ url });
   }
 
   trackSingleItem(item: string, properties?: TrackingEventProperties): void {
-    // eslint-disable-next-line no-console
-    console.log('UmamiProvider: trackSingleItem' + item, properties);
+    if (this.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('UmamiProvider: trackSingleItem' + item, properties);
+    }
     window.umami?.track(item, properties);
   }
 }


### PR DESCRIPTION
Without this PR, all analytics actions were unconditionally logged to console.
This PR introduces a `verbose` init prop, that allows to switch this off.

TODO: how do we want to deal with this for the console provider, which is explicitly made to allow for logging to browser console?