### PR TITLE
fix(ChatbotWelcomePrompt): Cards should be gallery layout

### DIFF
--- a/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.scss
+++ b/packages/module/src/ChatbotWelcomePrompt/ChatbotWelcomePrompt.scss
@@ -29,6 +29,8 @@
 
   .pf-chatbot__prompt-suggestions > * {
     flex: 1;
+    overflow: visible;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Cards should be the same height and shouldn't scroll. I think this crept in as part of docs changes. Regardless, we should handle different text lengths well.

| Before | After | 
|-|-|
|<img width="927" alt="Screenshot 2025-03-17 at 10 42 11 AM" src="https://github.com/user-attachments/assets/d5e3564c-21a8-4f45-86aa-72da61689dfb" />|<img width="950" alt="Screenshot 2025-03-17 at 10 40 46 AM" src="https://github.com/user-attachments/assets/7e8286b4-19e0-4a05-b8f0-1c3300283c75" />
|<img width="511" alt="Screenshot 2025-03-17 at 10 42 02 AM" src="https://github.com/user-attachments/assets/70520501-6636-4a8c-8295-a7c4ac2b0842" />|<img width="505" alt="Screenshot 2025-03-17 at 10 40 38 AM" src="https://github.com/user-attachments/assets/c5506d8d-2f5b-4f7a-affe-c2d7b877120c" />
