### PR TITLE
fix(MessageBar): RHDH-specific font size declaration

### DIFF
--- a/packages/module/src/MessageBar/MessageBar.scss
+++ b/packages/module/src/MessageBar/MessageBar.scss
@@ -73,6 +73,7 @@
     --pf-v6-c-form-control--PaddingBlockStart: 0;
     --pf-v6-c-form-control--PaddingBlockEnd: 0;
     --pf-v6-c-form-control--BorderRadius: 0;
+    font-family: var(--pf-t--global--font--family--body);
   }
   textarea:focus-visible {
     outline: none;


### PR DESCRIPTION
Red Hat Developer Hub is defaulting to monospace. PatternFly textareas inherit the font-family. This is causing a regression for them. We can declare a font-family in ChatBot to resolve this if we want to.