### PR TITLE
feat(Message): Allow passage of Button props onto links

### DIFF
--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -784,6 +784,20 @@ describe('Message', () => {
     // we are mocking rehype libraries, so we can't test target _blank addition on links directly with RTL
     expect(rehypeExternalLinks).not.toHaveBeenCalled();
   });
+  it('should handle extra link props correctly', async () => {
+    const spy = jest.fn();
+    render(
+      <Message
+        avatar="./img"
+        role="user"
+        name="User"
+        content={`[PatternFly](https://www.patternfly.org/)`}
+        linkProps={{ onClick: spy }}
+      />
+    );
+    await userEvent.click(screen.getByRole('link', { name: /PatternFly/i }));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
   it('should handle error correctly', () => {
     render(<Message avatar="./img" role="user" name="User" error={ERROR} />);
     expect(screen.getByRole('heading', { name: /Could not load chat/i })).toBeTruthy();

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -10,6 +10,7 @@ import {
   AlertProps,
   Avatar,
   AvatarProps,
+  ButtonProps,
   ContentVariants,
   Label,
   LabelGroupProps,
@@ -145,6 +146,8 @@ export interface MessageProps extends Omit<React.HTMLProps<HTMLDivElement>, 'rol
   openLinkInNewTab?: boolean;
   /** Optional inline error message that can be displayed in the message */
   error?: AlertProps;
+  /** Props for links */
+  linkProps?: ButtonProps;
 }
 
 export const MessageBase: React.FunctionComponent<MessageProps> = ({
@@ -173,6 +176,7 @@ export const MessageBase: React.FunctionComponent<MessageProps> = ({
   tableProps,
   openLinkInNewTab = true,
   additionalRehypePlugins = [],
+  linkProps,
   error,
   ...props
 }: MessageProps) => {
@@ -264,7 +268,7 @@ export const MessageBase: React.FunctionComponent<MessageProps> = ({
                       th: (props) => <ThMessage {...props} />,
                       img: (props) => <ImageMessage {...props} />,
                       a: (props) => (
-                        <LinkMessage href={props.href} rel={props.rel} target={props.target}>
+                        <LinkMessage href={props.href} rel={props.rel} target={props.target} {...linkProps}>
                           {props.children}
                         </LinkMessage>
                       )


### PR DESCRIPTION
Lightspeed was wondering if we could allow prop passing on links - putting up for after code freeze. 