### PR TITLE
chore(docs): Add demo for disabled quick response

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
@@ -40,5 +40,15 @@ export const MessageWithQuickResponsesExample: React.FunctionComponent = () => (
         { id: '5', content: 'Something else', onClick: () => alert('Clicked id 5') }
       ]}
     />
+    <Message
+      name="Bot"
+      role="bot"
+      avatar={patternflyAvatar}
+      content="Did you clear your cache?"
+      quickResponses={[
+        { id: '1', content: 'Yes', isDisabled: true },
+        { id: '2', content: 'No', onClick: () => alert('Clicked no') }
+      ]}
+    />
   </>
 );


### PR DESCRIPTION
Quick Response can take additional label props - document how to do this.

See https://chatbot-pr-chatbot-500.surge.sh/patternfly-ai/chatbot/messages#messages-with-quick-responses