### PR TITLE
add footer action button text props in Attachment components.

### DIFF
--- a/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AttachmentEdit, { AttachmentEditProps } from './AttachmentEdit';
 
@@ -67,8 +67,8 @@ describe('AttachmentEdit', () => {
       />
     );
 
-    screen.getByText('Save');
-    screen.getByText('Close');
+    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
   });
 
   it('should render AttachmentEdit with custom classNames', async () => {
@@ -88,11 +88,12 @@ describe('AttachmentEdit', () => {
       ></AttachmentEdit>
     );
 
-    const modalHeader = document.querySelector('header.custom-header-class');
-    expect(modalHeader).toBeInTheDocument();
-    const modalBody = document.querySelector('.custom-body-class');
-    expect(modalBody).toBeInTheDocument();
-    const modalfooter = document.querySelector('.custom-footer-class');
-    expect(modalfooter).toBeInTheDocument();
+    const modal = screen.getByRole('dialog');
+    const modalHeader = within(modal).getByRole('banner');
+    expect(modalHeader).toHaveClass('custom-header-class');
+    const modalBody = modal.querySelector('#code-modal-body');
+    expect(modalBody).toHaveClass('custom-body-class');
+    const modalfooter = within(modal).getByRole('contentinfo');
+    expect(modalfooter).toHaveClass('custom-footer-class');
   });
 });

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
@@ -51,4 +51,22 @@ describe('AttachmentEdit', () => {
     fireEvent.click(screen.getByText('Cancel'));
     expect(onCancelHandler).toHaveBeenCalled();
   });
+
+  it('should render custom button text for footer actions buttons', () => {
+    render(
+      <AttachmentEdit
+        code="Hello world"
+        fileName="greetings.txt"
+        isModalOpen={true}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        handleModalToggle={jest.fn()}
+        primaryActionButtonText="Save"
+        secondaryActionButtonText="Close"
+      />
+    );
+
+    screen.getByText('Save');
+    screen.getByText('Close');
+  });
 });

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import AttachmentEdit, { AttachmentEditProps } from './AttachmentEdit';
 
 describe('AttachmentEdit', () => {
@@ -68,5 +69,30 @@ describe('AttachmentEdit', () => {
 
     screen.getByText('Save');
     screen.getByText('Close');
+  });
+
+  it('should render AttachmentEdit with custom classNames', async () => {
+    render(
+      <AttachmentEdit
+        code="Hello world"
+        fileName="greetings.txt"
+        isModalOpen={true}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        handleModalToggle={jest.fn()}
+        primaryActionButtonText="Save"
+        secondaryActionButtonText="Close"
+        modalHeaderClassName="custom-header-class"
+        modalBodyClassName="custom-body-class"
+        modalFooterClassName="custom-footer-class"
+      ></AttachmentEdit>
+    );
+
+    const modalHeader = document.querySelector('header.custom-header-class');
+    expect(modalHeader).toBeInTheDocument();
+    const modalBody = document.querySelector('.custom-body-class');
+    expect(modalBody).toBeInTheDocument();
+    const modalfooter = document.querySelector('.custom-footer-class');
+    expect(modalfooter).toBeInTheDocument();
   });
 });

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
@@ -28,6 +28,12 @@ export interface AttachmentEditProps {
   primaryActionButtonText?: string;
   /** Secondary action button text */
   secondaryActionButtonText?: string;
+  /** Class applied to modal header */
+  modalHeaderClassName?: string;
+  /** Class applied to modal body */
+  modalBodyClassName?: string;
+  /** Class applied to modal footer */
+  modalFooterClassName?: string;
 }
 
 export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
@@ -40,6 +46,9 @@ export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
   title = 'Edit attachment',
   displayMode = ChatbotDisplayMode.default,
   isCompact,
+  modalHeaderClassName,
+  modalBodyClassName,
+  modalFooterClassName,
   primaryActionButtonText = 'Save',
   secondaryActionButtonText = 'Cancel'
 }: AttachmentEditProps) => {
@@ -66,6 +75,9 @@ export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
       title={title}
       displayMode={displayMode}
       isCompact={isCompact}
+      modalHeaderClassName={modalHeaderClassName}
+      modalBodyClassName={modalBodyClassName}
+      modalFooterClassName={modalFooterClassName}
     />
   );
 };

--- a/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
+++ b/packages/module/src/AttachmentEdit/AttachmentEdit.tsx
@@ -24,6 +24,10 @@ export interface AttachmentEditProps {
   displayMode?: ChatbotDisplayMode;
   /** Sets modal to compact styling. */
   isCompact?: boolean;
+  /** Primary action button text */
+  primaryActionButtonText?: string;
+  /** Secondary action button text */
+  secondaryActionButtonText?: string;
 }
 
 export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
@@ -35,7 +39,9 @@ export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
   onSave,
   title = 'Edit attachment',
   displayMode = ChatbotDisplayMode.default,
-  isCompact
+  isCompact,
+  primaryActionButtonText = 'Save',
+  secondaryActionButtonText = 'Cancel'
 }: AttachmentEditProps) => {
   const handleSave = (_event: ReactMouseEvent | MouseEvent | KeyboardEvent, code) => {
     handleModalToggle(_event);
@@ -55,8 +61,8 @@ export const AttachmentEdit: FunctionComponent<AttachmentEditProps> = ({
       isModalOpen={isModalOpen}
       onPrimaryAction={handleSave}
       onSecondaryAction={handleCancel}
-      primaryActionBtn="Save"
-      secondaryActionBtn="Cancel"
+      primaryActionBtn={primaryActionButtonText}
+      secondaryActionBtn={secondaryActionButtonText}
       title={title}
       displayMode={displayMode}
       isCompact={isCompact}

--- a/packages/module/src/CodeModal/CodeModal.test.tsx
+++ b/packages/module/src/CodeModal/CodeModal.test.tsx
@@ -20,4 +20,31 @@ describe('ChatbotModal', () => {
     );
     expect(screen.getByRole('dialog')).toHaveClass('pf-m-compact');
   });
+
+  it('should render CodeModal with custom classNames', async () => {
+    render(
+      <CodeModal
+        isCompact
+        code="Hello world"
+        fileName="greetings.txt"
+        isModalOpen={true}
+        handleModalToggle={jest.fn()}
+        onPrimaryAction={jest.fn()}
+        onSecondaryAction={jest.fn()}
+        title="Preview attachment"
+        primaryActionBtn="Submit"
+        secondaryActionBtn="Cancel"
+        modalHeaderClassName="custom-header-class"
+        modalBodyClassName="custom-body-class"
+        modalFooterClassName="custom-footer-class"
+      ></CodeModal>
+    );
+
+    const modalHeader = document.querySelector('header.custom-header-class');
+    expect(modalHeader).toBeInTheDocument();
+    const modalBody = document.querySelector('.custom-body-class');
+    expect(modalBody).toBeInTheDocument();
+    const modalfooter = document.querySelector('.custom-footer-class');
+    expect(modalfooter).toBeInTheDocument();
+  });
 });

--- a/packages/module/src/CodeModal/CodeModal.test.tsx
+++ b/packages/module/src/CodeModal/CodeModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CodeModal from './CodeModal';
 
@@ -40,11 +40,12 @@ describe('ChatbotModal', () => {
       ></CodeModal>
     );
 
-    const modalHeader = document.querySelector('header.custom-header-class');
-    expect(modalHeader).toBeInTheDocument();
-    const modalBody = document.querySelector('.custom-body-class');
-    expect(modalBody).toBeInTheDocument();
-    const modalfooter = document.querySelector('.custom-footer-class');
-    expect(modalfooter).toBeInTheDocument();
+    const modal = screen.getByRole('dialog');
+    const modalHeader = within(modal).getByRole('banner');
+    expect(modalHeader).toHaveClass('custom-header-class');
+    const modalBody = modal.querySelector('#code-modal-body');
+    expect(modalBody).toHaveClass('custom-body-class');
+    const modalfooter = within(modal).getByRole('contentinfo');
+    expect(modalfooter).toHaveClass('custom-footer-class');
   });
 });

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -43,6 +43,12 @@ export interface CodeModalProps {
   displayMode?: ChatbotDisplayMode;
   /** Sets modal to compact styling. */
   isCompact?: boolean;
+  /** Class applied to modal header */
+  modalHeaderClassName?: string;
+  /** Class applied to modal body */
+  modalBodyClassName?: string;
+  /** Class applied to modal footer */
+  modalFooterClassName?: string;
 }
 
 export const CodeModal: FunctionComponent<CodeModalProps> = ({
@@ -61,6 +67,9 @@ export const CodeModal: FunctionComponent<CodeModalProps> = ({
   title,
   displayMode = ChatbotDisplayMode.default,
   isCompact,
+  modalHeaderClassName,
+  modalBodyClassName,
+  modalFooterClassName,
   ...props
 }: CodeModalProps) => {
   const [newCode, setNewCode] = useState(code);
@@ -102,8 +111,8 @@ export const CodeModal: FunctionComponent<CodeModalProps> = ({
       displayMode={displayMode}
       isCompact={isCompact}
     >
-      <ModalHeader title={title} labelId="code-modal-title" />
-      <ModalBody id="code-modal-body">
+      <ModalHeader className={modalHeaderClassName} title={title} labelId="code-modal-title" />
+      <ModalBody className={modalBodyClassName} id="code-modal-body">
         <Stack className="pf-chatbot__code-modal-body">
           <StackItem className="pf-chatbot__code-modal-file-details">
             <FileDetails fileName={fileName} />
@@ -130,7 +139,7 @@ export const CodeModal: FunctionComponent<CodeModalProps> = ({
           </StackItem>
         </Stack>
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className={modalFooterClassName}>
         <Button isBlock key="code-modal-primary" variant="primary" onClick={handlePrimaryAction} form="code-modal-form">
           {primaryActionBtn}
         </Button>

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PreviewAttachment } from './PreviewAttachment';
 
@@ -82,11 +82,12 @@ describe('PreviewAttachment', () => {
       ></PreviewAttachment>
     );
 
-    const modalHeader = document.querySelector('header.custom-header-class');
-    expect(modalHeader).toBeInTheDocument();
-    const modalBody = document.querySelector('.custom-body-class');
-    expect(modalBody).toBeInTheDocument();
-    const modalfooter = document.querySelector('.custom-footer-class');
-    expect(modalfooter).toBeInTheDocument();
+    const modal = screen.getByRole('dialog');
+    const modalHeader = within(modal).getByRole('banner');
+    expect(modalHeader).toHaveClass('custom-header-class');
+    const modalBody = modal.querySelector('#code-modal-body');
+    expect(modalBody).toHaveClass('custom-body-class');
+    const modalfooter = within(modal).getByRole('contentinfo');
+    expect(modalfooter).toHaveClass('custom-footer-class');
   });
 });

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
@@ -47,4 +47,21 @@ describe('PreviewAttachment', () => {
 
     expect(onDismiss).toHaveBeenCalled();
   });
+
+  it('should render custom button text for footer actions buttons', () => {
+    render(
+      <PreviewAttachment
+        code="Hello world"
+        fileName="greetings.txt"
+        isModalOpen={true}
+        onEdit={jest.fn()}
+        handleModalToggle={jest.fn()}
+        primaryActionButtonText="Edit"
+        secondaryActionButtonText="Close"
+      />
+    );
+
+    screen.getByText('Edit');
+    screen.getByText('Close');
+  });
 });

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { PreviewAttachment } from './PreviewAttachment';
 
 describe('PreviewAttachment', () => {
@@ -63,5 +64,29 @@ describe('PreviewAttachment', () => {
 
     screen.getByText('Edit');
     screen.getByText('Close');
+  });
+
+  it('should render PreviewAttachment with custom classNames', async () => {
+    render(
+      <PreviewAttachment
+        code="Hello world"
+        fileName="greetings.txt"
+        isModalOpen={true}
+        onEdit={jest.fn()}
+        handleModalToggle={jest.fn()}
+        primaryActionButtonText="Edit"
+        secondaryActionButtonText="Close"
+        modalHeaderClassName="custom-header-class"
+        modalBodyClassName="custom-body-class"
+        modalFooterClassName="custom-footer-class"
+      ></PreviewAttachment>
+    );
+
+    const modalHeader = document.querySelector('header.custom-header-class');
+    expect(modalHeader).toBeInTheDocument();
+    const modalBody = document.querySelector('.custom-body-class');
+    expect(modalBody).toBeInTheDocument();
+    const modalfooter = document.querySelector('.custom-footer-class');
+    expect(modalfooter).toBeInTheDocument();
   });
 });

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
@@ -28,6 +28,12 @@ export interface PreviewAttachmentProps {
   primaryActionButtonText?: string;
   /** Secondary action button text */
   secondaryActionButtonText?: string;
+  /** Class applied to modal header */
+  modalHeaderClassName?: string;
+  /** Class applied to modal body */
+  modalBodyClassName?: string;
+  /** Class applied to modal footer */
+  modalFooterClassName?: string;
 }
 
 export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
@@ -41,6 +47,9 @@ export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
   primaryActionButtonText = 'Edit',
   secondaryActionButtonText = 'Dismiss',
   displayMode = ChatbotDisplayMode.default,
+  modalHeaderClassName,
+  modalBodyClassName,
+  modalFooterClassName,
   isCompact
 }: PreviewAttachmentProps) => {
   const handleEdit = (_event: MouseEvent | MouseEvent | KeyboardEvent) => {
@@ -70,6 +79,9 @@ export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
       isReadOnly
       displayMode={displayMode}
       isCompact={isCompact}
+      modalHeaderClassName={modalHeaderClassName}
+      modalBodyClassName={modalBodyClassName}
+      modalFooterClassName={modalFooterClassName}
     />
   );
 };

--- a/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
+++ b/packages/module/src/PreviewAttachment/PreviewAttachment.tsx
@@ -24,6 +24,10 @@ export interface PreviewAttachmentProps {
   displayMode?: ChatbotDisplayMode;
   /** Sets modal to compact styling. */
   isCompact?: boolean;
+  /** Primary action button text */
+  primaryActionButtonText?: string;
+  /** Secondary action button text */
+  secondaryActionButtonText?: string;
 }
 
 export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
@@ -34,6 +38,8 @@ export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
   onDismiss = undefined,
   onEdit,
   title = 'Preview attachment',
+  primaryActionButtonText = 'Edit',
+  secondaryActionButtonText = 'Dismiss',
   displayMode = ChatbotDisplayMode.default,
   isCompact
 }: PreviewAttachmentProps) => {
@@ -58,8 +64,8 @@ export const PreviewAttachment: FunctionComponent<PreviewAttachmentProps> = ({
       isModalOpen={isModalOpen}
       onPrimaryAction={handleEdit}
       onSecondaryAction={handleDismiss}
-      primaryActionBtn="Edit"
-      secondaryActionBtn="Dismiss"
+      primaryActionBtn={primaryActionButtonText}
+      secondaryActionBtn={secondaryActionButtonText}
       title={title}
       isReadOnly
       displayMode={displayMode}


### PR DESCRIPTION

Fixes:

https://github.com/patternfly/chatbot/issues/551

**Description:**

add footer action button text props in Preview/Edit Attachment components.