### PR TITLE
feat(CodeBlockMessage/Message): Add expandable code block

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -15,11 +15,13 @@ export const BotMessageExample: FunctionComponent = () => {
   const [variant, setVariant] = useState<string>('Code');
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<string>('Message content type');
+  const [isExpandable, setIsExpanded] = useState(false);
 
   /* eslint-disable indent */
   const renderContent = () => {
     switch (variant) {
       case 'Code':
+      case 'Expandable code':
         return code;
       case 'Heading':
         return heading;
@@ -166,6 +168,11 @@ _Italic text, formatted with single underscores_
     setVariant(value);
     setSelected(value as string);
     setIsOpen(false);
+    if (value === 'Expandable code') {
+      setIsExpanded(true);
+    } else {
+      setIsExpanded(false);
+    }
   };
 
   const onToggleClick = () => {
@@ -237,6 +244,7 @@ _Italic text, formatted with single underscores_
       >
         <SelectList>
           <SelectOption value="Code">Code</SelectOption>
+          <SelectOption value="Expandable code">Expandable code</SelectOption>
           <SelectOption value="Inline code">Inline code</SelectOption>
           <SelectOption value="Heading">Heading</SelectOption>
           <SelectOption value="Block quotes">Block quotes</SelectOption>
@@ -259,6 +267,7 @@ _Italic text, formatted with single underscores_
           variant === 'Table' ? { 'aria-label': 'App information and user roles for bot messages' } : undefined
         }
         error={variant === 'Error' ? error : undefined}
+        codeBlockProps={{ isExpandable }}
       />
     </>
   );

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -267,7 +267,7 @@ _Italic text, formatted with single underscores_
           variant === 'Table' ? { 'aria-label': 'App information and user roles for bot messages' } : undefined
         }
         error={variant === 'Error' ? error : undefined}
-        codeBlockProps={{ isExpandable }}
+        codeBlockProps={{ isExpandable, expandableSectionProps: { truncateMaxLines: isExpandable ? 1 : undefined } }}
       />
     </>
   );

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -15,11 +15,13 @@ export const UserMessageExample: FunctionComponent = () => {
   const [isEditable, setIsEditable] = useState<boolean>(true);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<string>('Message content type');
+  const [isExpandable, setIsExpanded] = useState(false);
 
   /* eslint-disable indent */
   const renderContent = () => {
     switch (variant) {
       case 'Code':
+      case 'Expandable code':
         return code;
       case 'Inline code':
         return inlineCode;
@@ -166,6 +168,11 @@ _Italic text, formatted with single underscores_
     setVariant(value);
     setSelected(value as string);
     setIsOpen(false);
+    if (value === 'Expandable code') {
+      setIsExpanded(true);
+    } else {
+      setIsExpanded(false);
+    }
   };
 
   const onToggleClick = () => {
@@ -215,6 +222,7 @@ _Italic text, formatted with single underscores_
       >
         <SelectList>
           <SelectOption value="Code">Code</SelectOption>
+          <SelectOption value="Expandable code">Expandable code</SelectOption>
           <SelectOption value="Inline code">Inline code</SelectOption>
           <SelectOption value="Heading">Heading</SelectOption>
           <SelectOption value="Block quotes">Block quotes</SelectOption>
@@ -241,6 +249,7 @@ _Italic text, formatted with single underscores_
         error={variant === 'Error' ? error : undefined}
         onEditUpdate={() => setIsEditable(false)}
         onEditCancel={() => setIsEditable(false)}
+        codeBlockProps={{ isExpandable }}
       />
     </>
   );

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -249,7 +249,7 @@ _Italic text, formatted with single underscores_
         error={variant === 'Error' ? error : undefined}
         onEditUpdate={() => setIsEditable(false)}
         onEditCancel={() => setIsEditable(false)}
-        codeBlockProps={{ isExpandable }}
+        codeBlockProps={{ isExpandable, expandableSectionProps: { truncateMaxLines: isExpandable ? 1 : undefined } }}
       />
     </>
   );

--- a/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.scss
+++ b/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.scss
@@ -80,3 +80,10 @@
   background-color: var(--pf-t--global--background--color--tertiary--default);
   font-size: var(--pf-t--global--font--size--body--default);
 }
+
+.pf-chatbot__message-code-toggle {
+  .pf-v6-c-button.pf-m-link {
+    --pf-v6-c-button--m-link--Color: var(--pf-t--global--border--color--nonstatus--blue--default);
+    --pf-v6-c-button--hover--Color: var(--pf-t--global--border--color--nonstatus--blue--hover);
+  }
+}

--- a/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.scss
+++ b/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.scss
@@ -83,7 +83,7 @@
 
 .pf-chatbot__message-code-toggle {
   .pf-v6-c-button.pf-m-link {
-    --pf-v6-c-button--m-link--Color: var(--pf-t--global--border--color--nonstatus--blue--default);
-    --pf-v6-c-button--hover--Color: var(--pf-t--global--border--color--nonstatus--blue--hover);
+    --pf-v6-c-button--m-link--Color: var(--pf-t--global--color--nonstatus--blue--default);
+    --pf-v6-c-button--hover--Color: var(--pf-t--global--color--nonstatus--blue--hover);
   }
 }

--- a/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
+++ b/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
@@ -49,8 +49,8 @@ const CodeBlockMessage = ({
   maxLength = 10,
   expandableSectionProps,
   expandableSectionToggleProps,
-  expandedText = 'Show Less',
-  collapsedText = 'Show More',
+  expandedText = 'Show less',
+  collapsedText = 'Show more',
   ...props
 }: CodeBlockProps) => {
   const [copied, setCopied] = useState(false);

--- a/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
+++ b/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
@@ -5,24 +5,93 @@ import { useState, useRef, useId, useCallback, useEffect } from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { obsidian } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 // Import PatternFly components
-import { CodeBlock, CodeBlockAction, CodeBlockCode, Button, Tooltip } from '@patternfly/react-core';
+import {
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  Button,
+  Tooltip,
+  ExpandableSection,
+  ExpandableSectionToggle,
+  ExpandableSectionProps,
+  ExpandableSectionToggleProps
+} from '@patternfly/react-core';
 
 import { CheckIcon } from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { CopyIcon } from '@patternfly/react-icons/dist/esm/icons/copy-icon';
-import { ExtraProps } from 'react-markdown';
+
+export interface CodeBlockProps {
+  /** Content rendered in code block */
+  children?: React.ReactNode;
+  /** Aria label applied to code block */
+  'aria-label'?: string;
+  /** Class name applied to code block */
+  className?: string;
+  /** Whether code block is expandable */
+  isExpandable?: boolean;
+  /** Length of text initially shown in expandable code block; defaults to 10 characters */
+  maxLength?: number;
+  /** Additional props passed to expandable section if isExpandable is applied */
+  expandableSectionProps?: Omit<ExpandableSectionProps, 'ref'>;
+  /** Additional props passed to expandable toggle if isExpandable is applied */
+  expandableSectionToggleProps?: ExpandableSectionToggleProps;
+  /** Link text applied to expandable toggle when expanded */
+  expandedText?: string;
+  /** Link text applied to expandable toggle when collapsed */
+  collapsedText?: string;
+}
 
 const CodeBlockMessage = ({
   children,
   className,
   'aria-label': ariaLabel,
+  isExpandable = false,
+  maxLength = 10,
+  expandableSectionProps,
+  expandableSectionToggleProps,
+  expandedText = 'Show Less',
+  collapsedText = 'Show More',
   ...props
-}: Omit<JSX.IntrinsicElements['code'], 'ref'> & ExtraProps) => {
+}: CodeBlockProps) => {
   const [copied, setCopied] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [initialWidth, setInitialWidth] = useState<number | null>(null);
 
-  const buttonRef = useRef(undefined);
+  const buttonRef = useRef();
   const tooltipID = useId();
+  const toggleId = useId();
+  const contentId = useId();
+  const codeBlockRef = useRef<HTMLDivElement>(null);
+
+  // Keeps the width the same - this can vary when content is expandable
+  useEffect(() => {
+    if (codeBlockRef.current) {
+      let ancestor = codeBlockRef.current.parentNode;
+      if (ancestor) {
+        ancestor = ancestor.parentNode;
+        if (ancestor) {
+          ancestor = ancestor.parentNode;
+          if (ancestor && ancestor instanceof HTMLElement) {
+            setInitialWidth(ancestor.offsetWidth);
+          }
+        }
+      }
+    }
+  }, []);
+
+  let code;
+  let expandedCode;
+
+  if (isExpandable && maxLength && children) {
+    code = String(children).substring(0, maxLength);
+    expandedCode = String(children).substring(maxLength);
+  }
 
   const language = /language-(\w+)/.exec(className || '')?.[1];
+
+  const onToggle = (isExpanded) => {
+    setIsExpanded(isExpanded);
+  };
 
   // Handle clicking copy button
   const handleCopy = useCallback((event, text) => {
@@ -68,18 +137,48 @@ const CodeBlockMessage = ({
     </>
   );
 
+  const expandableSyntax = String(isExpanded ? children : code).replace(/\n$/, '');
+  const codeBlockStyle = initialWidth !== null ? { width: `${initialWidth}px` } : {};
+
   return (
-    <div className="pf-chatbot__message-code-block">
+    <div className="pf-chatbot__message-code-block" ref={codeBlockRef} style={codeBlockStyle}>
       <CodeBlock actions={actions}>
         <CodeBlockCode>
           {language ? (
             <SyntaxHighlighter {...props} language={language} style={obsidian} PreTag="div" CodeTag="div" wrapLongLines>
-              {String(children).replace(/\n$/, '')}
+              {isExpandable ? expandableSyntax : String(children).replace(/\n$/, '')}
             </SyntaxHighlighter>
           ) : (
-            <>{children}</>
+            <>
+              {isExpandable ? code : children}
+              {isExpandable && (
+                <ExpandableSection
+                  isExpanded={isExpanded}
+                  isDetached
+                  toggleId={toggleId}
+                  contentId={contentId}
+                  {...expandableSectionProps}
+                >
+                  {expandedCode}
+                </ExpandableSection>
+              )}
+            </>
           )}
         </CodeBlockCode>
+        {isExpandable && (
+          <ExpandableSectionToggle
+            isExpanded={isExpanded}
+            onToggle={onToggle}
+            direction="up"
+            toggleId={toggleId}
+            contentId={contentId}
+            hasTruncatedContent
+            className="pf-chatbot__message-code-toggle"
+            {...expandableSectionToggleProps}
+          >
+            {isExpanded ? expandedText : collapsedText}
+          </ExpandableSectionToggle>
+        )}
       </CodeBlock>
     </div>
   );

--- a/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
+++ b/packages/module/src/Message/CodeBlockMessage/CodeBlockMessage.tsx
@@ -20,7 +20,7 @@ import {
 import { CheckIcon } from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { CopyIcon } from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 
-export interface CodeBlockProps {
+export interface CodeBlockMessageProps {
   /** Content rendered in code block */
   children?: React.ReactNode;
   /** Aria label applied to code block */
@@ -52,7 +52,7 @@ const CodeBlockMessage = ({
   expandedText = 'Show less',
   collapsedText = 'Show more',
   ...props
-}: CodeBlockProps) => {
+}: CodeBlockMessageProps) => {
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [initialWidth, setInitialWidth] = useState<number | null>(null);
@@ -66,6 +66,7 @@ const CodeBlockMessage = ({
   // Keeps the width the same - this can vary when content is expandable
   useEffect(() => {
     if (codeBlockRef.current) {
+      // This is parent .pf-chatbot__message-code-block if it exists
       let ancestor = codeBlockRef.current.parentNode;
       if (ancestor) {
         ancestor = ancestor.parentNode;

--- a/packages/module/src/Message/CodeBlockMessage/ExpandableSectionForSyntaxHighlighter.tsx
+++ b/packages/module/src/Message/CodeBlockMessage/ExpandableSectionForSyntaxHighlighter.tsx
@@ -1,0 +1,220 @@
+import { Component, createRef } from 'react';
+import styles from '@patternfly/react-styles/css/components/ExpandableSection/expandable-section';
+import { css } from '@patternfly/react-styles';
+import lineClamp from '@patternfly/react-tokens/dist/esm/c_expandable_section_m_truncate__content_LineClamp';
+import { debounce, getResizeObserver, getUniqueId, PickOptional } from '@patternfly/react-core';
+
+export enum ExpandableSectionVariant {
+  default = 'default',
+  truncate = 'truncate'
+}
+
+/** The main expandable section component. */
+
+export interface ExpandableSectionProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onToggle'> {
+  /** Content rendered inside the expandable section. */
+  children?: React.ReactNode;
+  /** Additional classes added to the expandable section. */
+  className?: string;
+  /** Id of the content of the expandable section. When passing in the isDetached property, this
+   * property's value should match the contentId property of the expandable section toggle sub-component.
+   */
+  contentId?: string;
+  /** Id of the toggle of the expandable section, which provides an accessible name to the
+   * expandable section content via the aria-labelledby attribute. When the isDetached property
+   * is also passed in, the value of this property must match the toggleId property of the
+   * expandable section toggle sub-component.
+   */
+  toggleId?: string;
+  /** Display size variant. Set to "lg" for disclosure styling. */
+  displaySize?: 'default' | 'lg';
+  /** Indicates the expandable section has a detached toggle. */
+  isDetached?: boolean;
+  /** Flag to indicate if the content is expanded. */
+  isExpanded?: boolean;
+  /** Flag to indicate if the content is indented. */
+  isIndented?: boolean;
+  /** Flag to indicate the width of the component is limited. Set to "true" for disclosure styling. */
+  isWidthLimited?: boolean;
+  /** Truncates the expandable content to the specified number of lines when using the
+   * "truncate" variant.
+   */
+  truncateMaxLines?: number;
+  /** Determines the variant of the expandable section. When passing in "truncate" as the
+   * variant, the expandable content will be truncated after 3 lines by default.
+   */
+  variant?: 'default' | 'truncate';
+  language?: string;
+}
+
+interface ExpandableSectionState {
+  isExpanded: boolean;
+  hasToggle: boolean;
+  previousWidth: number | undefined;
+}
+
+const setLineClamp = (element: HTMLDivElement | null, lines?: number, language?: string, isExpanded?: boolean) => {
+  if (!element || !lines || lines < 1 || typeof isExpanded === 'undefined') {
+    return;
+  }
+
+  if (language) {
+    const selector = `.language-${language.toLowerCase()}`;
+    const childElement = element.querySelector(selector) as HTMLDivElement;
+
+    if (!childElement) {
+      return;
+    }
+    if (isExpanded) {
+      // Reset all truncation-related styles to their default values
+      childElement.style.removeProperty('-webkit-line-clamp');
+      childElement.style.removeProperty('display');
+      childElement.style.removeProperty('-webkit-box-orient');
+      childElement.style.removeProperty('overflow');
+    } else {
+      childElement.style.setProperty('-webkit-line-clamp', lines.toString());
+      childElement.style.setProperty('display', '-webkit-box');
+      childElement.style.setProperty('-webkit-box-orient', 'vertical');
+      childElement.style.setProperty('overflow', 'hidden');
+    }
+  }
+};
+
+class ExpandableSectionForSyntaxHighlighter extends Component<ExpandableSectionProps, ExpandableSectionState> {
+  static displayName = 'ExpandableSection';
+  constructor(props: ExpandableSectionProps) {
+    super(props);
+
+    this.state = {
+      isExpanded: props.isExpanded ?? false,
+      hasToggle: true,
+      previousWidth: undefined
+    };
+  }
+
+  expandableContentRef = createRef<HTMLDivElement>();
+  /* eslint-disable-next-line */
+  observer: any = () => {};
+
+  static defaultProps: PickOptional<ExpandableSectionProps> = {
+    className: '',
+    isDetached: false,
+    displaySize: 'default',
+    isWidthLimited: false,
+    isIndented: false,
+    variant: 'default'
+  };
+
+  componentDidMount() {
+    if (this.props.variant === ExpandableSectionVariant.truncate) {
+      const expandableContent = this.expandableContentRef.current;
+      if (expandableContent) {
+        this.setState({ previousWidth: expandableContent.offsetWidth });
+        this.observer = getResizeObserver(expandableContent, this.handleResize, false);
+
+        if (this.props.truncateMaxLines) {
+          setLineClamp(expandableContent, this.props.truncateMaxLines, this.props.language, this.state.isExpanded);
+        }
+      }
+
+      this.checkToggleVisibility();
+    }
+  }
+
+  componentDidUpdate(prevProps: ExpandableSectionProps) {
+    if (
+      this.props.variant === ExpandableSectionVariant.truncate &&
+      (prevProps.truncateMaxLines !== this.props.truncateMaxLines ||
+        prevProps.children !== this.props.children ||
+        prevProps.isExpanded !== this.props.isExpanded)
+    ) {
+      const expandableContent = this.expandableContentRef.current;
+      setLineClamp(expandableContent, this.props.truncateMaxLines, this.props.language, this.props.isExpanded);
+      this.checkToggleVisibility();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.variant === ExpandableSectionVariant.truncate) {
+      this.observer();
+    }
+  }
+
+  checkToggleVisibility = () => {
+    if (this.expandableContentRef?.current) {
+      const maxLines = this.props.truncateMaxLines || parseInt(lineClamp.value);
+      const totalLines =
+        this.expandableContentRef.current.scrollHeight /
+        parseInt(getComputedStyle(this.expandableContentRef.current).lineHeight);
+
+      this.setState({
+        hasToggle: totalLines > maxLines
+      });
+    }
+  };
+
+  resize = () => {
+    if (this.expandableContentRef.current) {
+      const { offsetWidth } = this.expandableContentRef.current;
+      if (this.state.previousWidth !== offsetWidth) {
+        this.setState({ previousWidth: offsetWidth });
+        this.checkToggleVisibility();
+      }
+    }
+  };
+  handleResize = debounce(this.resize, 250);
+
+  render() {
+    const {
+      className,
+      children,
+      isExpanded,
+      isDetached,
+      displaySize,
+      isWidthLimited,
+      isIndented,
+      contentId,
+      toggleId,
+      variant,
+      ...props
+    } = this.props;
+
+    if (isDetached && !toggleId) {
+      /* eslint-disable no-console */
+      console.warn(
+        'ExpandableSection: The toggleId value must be passed in and must match the toggleId of the ExpandableSectionToggle.'
+      );
+    }
+
+    const uniqueContentId = contentId || getUniqueId('expandable-section-content');
+    const uniqueToggleId = toggleId || getUniqueId('expandable-section-toggle');
+
+    return (
+      <div
+        className={css(
+          styles.expandableSection,
+          isExpanded && styles.modifiers.expanded,
+          displaySize === 'lg' && styles.modifiers.displayLg,
+          isWidthLimited && styles.modifiers.limitWidth,
+          isIndented && styles.modifiers.indented,
+          variant === ExpandableSectionVariant.truncate && styles.modifiers.truncate,
+          className
+        )}
+        {...props}
+      >
+        <div
+          ref={this.expandableContentRef}
+          className={css(styles.expandableSectionContent)}
+          hidden={variant !== ExpandableSectionVariant.truncate && !isExpanded}
+          id={uniqueContentId}
+          aria-labelledby={uniqueToggleId}
+          role="region"
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+}
+
+export { ExpandableSectionForSyntaxHighlighter };

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -499,6 +499,36 @@ describe('Message', () => {
       screen.getByText(/https:\/\/raw.githubusercontent.com\/Azure-Samples\/helm-charts\/master\/docs/i)
     ).toBeTruthy();
   });
+  it('should render expandable code correctly', () => {
+    render(
+      <Message avatar="./img" role="user" name="User" content={CODE_MESSAGE} codeBlockProps={{ isExpandable: true }} />
+    );
+    expect(screen.getByText('Here is some YAML code:')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeTruthy();
+    expect(screen.getByText(/yaml/)).toBeTruthy();
+    expect(screen.getByText(/apiVersion/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Show more/i })).toBeTruthy();
+  });
+  it('should handle click on expandable code correctly', async () => {
+    render(
+      <Message avatar="./img" role="user" name="User" content={CODE_MESSAGE} codeBlockProps={{ isExpandable: true }} />
+    );
+    const button = screen.getByRole('button', { name: /Show more/i });
+    await userEvent.click(button);
+    expect(screen.getByRole('button', { name: /Show less/i })).toBeTruthy();
+    expect(screen.getByText(/yaml/)).toBeTruthy();
+    expect(screen.getByText(/apiVersion:/i)).toBeTruthy();
+    expect(screen.getByText(/helm.openshift.io\/v1beta1/i)).toBeTruthy();
+    expect(screen.getByText(/metadata:/i)).toBeTruthy();
+    expect(screen.getByText(/name:/i)).toBeTruthy();
+    expect(screen.getByText(/azure-sample-repo0oooo00ooo/i)).toBeTruthy();
+    expect(screen.getByText(/spec/i)).toBeTruthy();
+    expect(screen.getByText(/connectionConfig:/i)).toBeTruthy();
+    expect(screen.getByText(/url:/i)).toBeTruthy();
+    expect(
+      screen.getByText(/https:\/\/raw.githubusercontent.com\/Azure-Samples\/helm-charts\/master\/docs/i)
+    ).toBeTruthy();
+  });
   it('can click copy code button', async () => {
     // need explicit setup since RTL stubs clipboard if you do this
     const user = userEvent.setup();

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -11,6 +11,8 @@ import {
   AvatarProps,
   ButtonProps,
   ContentVariants,
+  ExpandableSectionProps,
+  ExpandableSectionToggleProps,
   FormProps,
   Label,
   LabelGroupProps,
@@ -106,9 +108,24 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   botWord?: string;
   /** Label for the English "Loading message," displayed to screenreaders when loading a message */
   loadingWord?: string;
+  /** Props for code blocks */
   codeBlockProps?: {
+    /** Aria label applied to code block */
     'aria-label'?: string;
+    /** Class name applied to code block */
     className?: string;
+    /** Whether code block is expandable */
+    isExpandable?: boolean;
+    /** Length of text initially shown in expandable code block; defaults to 10 characters */
+    maxLength?: number;
+    /** Additional props passed to expandable section if isExpandable is applied */
+    expandableSectionProps?: Omit<ExpandableSectionProps, 'ref'>;
+    /** Additional props passed to expandable toggle if isExpandable is applied */
+    expandableSectionToggleProps?: ExpandableSectionToggleProps;
+    /** Link text applied to expandable toggle when expanded */
+    expandedText?: string;
+    /** Link text applied to expandable toggle when collapsed */
+    collapsedText?: string;
   };
   /** Props for quick responses */
   quickResponses?: QuickResponse[];

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -110,13 +110,13 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   loadingWord?: string;
   /** Props for code blocks */
   codeBlockProps?: {
-    /** Aria label applied to code block */
+    /** Aria label applied to code blocks */
     'aria-label'?: string;
-    /** Class name applied to code block */
+    /** Class name applied to code blocks */
     className?: string;
-    /** Whether code block is expandable */
+    /** Whether code blocks are expandable */
     isExpandable?: boolean;
-    /** Length of text initially shown in expandable code block; defaults to 10 characters */
+    /** Length of text initially shown in expandable code blocks; defaults to 10 characters */
     maxLength?: number;
     /** Additional props passed to expandable section if isExpandable is applied */
     expandableSectionProps?: Omit<ExpandableSectionProps, 'ref'>;


### PR DESCRIPTION
This was a request from RHDH product manager - wanted to be able to make code blocks optionally expandable. They were fine with having it applied to all code blocks in message - they envision having it applied to all user messages by default.

Kayla wanted the truncated toggle applied by default - it sounds like design will have general PF migrate in that direction soon.

<img width="634" alt="Screenshot 2025-05-21 at 9 53 04 AM" src="https://github.com/user-attachments/assets/41d2dd98-4f25-4091-a2f3-ca36ec67510c" />
<img width="638" alt="Screenshot 2025-05-21 at 9 52 47 AM" src="https://github.com/user-attachments/assets/7e9d7cd1-1717-446c-89c2-91e45c885051" />

Docs: https://chatbot-pr-chatbot-556.surge.sh/patternfly-ai/chatbot/messages (go to user or bot message and select "expandable code" option from dropdown.)