### PR TITLE
fix `isClicked` prop in ResponseActions component

### DIFF
--- a/packages/module/src/ResponseActions/ResponseActions.tsx
+++ b/packages/module/src/ResponseActions/ResponseActions.tsx
@@ -55,6 +55,30 @@ export interface ResponseActionProps {
 
 export const ResponseActions: FunctionComponent<ResponseActionProps> = ({ actions }) => {
   const [activeButton, setActiveButton] = useState<string>();
+  useEffect(() => {
+    // Define the order of precedence for checking initial `isClicked`
+    const actionPrecedence = ['positive', 'negative', 'copy', 'share', 'download', 'listen'];
+    let initialActive: string | undefined;
+
+    // Check predefined actions first based on precedence
+    for (const actionName of actionPrecedence) {
+      const actionProp = actions[actionName as keyof typeof actions];
+      if (actionProp?.isClicked) {
+        initialActive = actionName;
+        break;
+      }
+    }
+    // If no predefined action was initially clicked, check additionalActions
+    if (!initialActive) {
+      const clickedActionName = Object.keys(additionalActions).find(
+        (actionName) => !actionPrecedence.includes(actionName) && additionalActions[actionName]?.isClicked
+      );
+      initialActive = clickedActionName;
+    }
+
+    setActiveButton(initialActive);
+  }, [actions]);
+
   const { positive, negative, copy, share, download, listen, ...additionalActions } = actions;
   const responseActions = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Fixes:
https://github.com/patternfly/chatbot/issues/578

This PR allows external control over the click state, which is necessary for certain use cases such as displaying a pre-clicked state especially when the feedback actions are persisted.


| Before fix (positive button is not active)    | After fix (positive button is active) |
| -------- | ------- |
| ![before_fix](https://github.com/user-attachments/assets/e5f1433b-db7b-4485-8cd2-e9c236ca4b52)  | ![after_fix](https://github.com/user-attachments/assets/6f8384c4-545d-4045-b898-86ed7bd54792)   |



