### PR TITLE
fix(ResponseActions): Adjust spacing so it's consistent

### DIFF
--- a/packages/module/src/Message/TextMessage/TextMessage.scss
+++ b/packages/module/src/Message/TextMessage/TextMessage.scss
@@ -3,16 +3,13 @@
 // ============================================================================
 
 .pf-chatbot__message-and-actions {
+  width: 100%;
+
   blockquote {
     .pf-chatbot__message-text {
       display: inline-block;
     }
   }
-}
-
-// make it full width when there's a table, so the table can grow as needed
-.pf-chatbot__message-and-actions:has(.pf-chatbot__message-table) {
-  width: 100%;
 }
 
 // Need to inline shorter text


### PR DESCRIPTION
Previously spacing could vary based on size of parent message - switching to 100% of space.

| Before | After |
|-|-|
![Image](https://github.com/user-attachments/assets/f2448641-91d0-4d1e-ad86-5014a65cdeb9)|<img width="706" alt="Screenshot 2025-06-13 at 2 08 18 PM" src="https://github.com/user-attachments/assets/11f6bb1f-c009-4436-b355-1eab7afa52a0" />
