### PR TITLE
feat(Button): add new chat button and icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@octokit/rest": "^18.0.0",
-        "@patternfly/documentation-framework": "6.8.2",
+        "@patternfly/documentation-framework": "6.16.0",
         "@patternfly/patternfly": "^6.1.0",
         "@patternfly/react-icons": "^6.1.0",
         "@patternfly/react-table": "^6.1.0",
@@ -3287,7 +3287,9 @@
       "link": true
     },
     "node_modules/@patternfly/documentation-framework": {
-      "version": "6.8.2",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.16.0.tgz",
+      "integrity": "sha512-E4VW07YolVx22ZQcPJqeeN2QJWyZUZA1892RlPLQl4h6Eo/P+GR3AxraI6uRf5MICuAaLBJMFoczeYWa22uuuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3295,7 +3297,7 @@
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@mdx-js/util": "1.6.16",
-        "@patternfly/ast-helpers": "^1.4.0-alpha.170",
+        "@patternfly/ast-helpers": "^1.4.0-alpha.252",
         "@reach/router": "npm:@gatsbyjs/reach-router@1.3.9",
         "autoprefixer": "9.8.6",
         "babel-loader": "^9.1.3",
@@ -3358,10 +3360,10 @@
         "pf-docs-framework": "scripts/cli/cli.js"
       },
       "peerDependencies": {
-        "@patternfly/patternfly": "^6.2.0",
-        "@patternfly/react-code-editor": "^6.2.0",
-        "@patternfly/react-core": "^6.2.0",
-        "@patternfly/react-table": "^6.2.0",
+        "@patternfly/patternfly": "^6.3.0",
+        "@patternfly/react-code-editor": "^6.3.0",
+        "@patternfly/react-core": "^6.3.0",
+        "@patternfly/react-table": "^6.3.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
@@ -3516,7 +3518,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.3.0.tgz",
+      "integrity": "sha512-I/Z0uuaVYfv9QqNAP2/iCGUGhUb0idatNTfFLQk0VnUi2hSMgznDogvAjmlVtZu2DW0P0FymS0oo5EjL+uW6Dg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3561,19 +3565,21 @@
       }
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.3.0.tgz",
+      "integrity": "sha512-2G0LId2KuuMcFZJRLDcRMfMHWRFG/sbMPXyD8yIi/2LPtAh/JFHbbDCzQXveQzaFhwXxVyVdCrCmbgn4SDYDlQ==",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^6.2.0",
-        "@patternfly/react-icons": "^6.2.0",
-        "@patternfly/react-styles": "^6.2.0",
+        "@patternfly/react-core": "^6.3.0",
+        "@patternfly/react-icons": "^6.3.0",
+        "@patternfly/react-styles": "^6.3.0",
         "react-dropzone": "14.3.5",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-code-editor/node_modules/react-dropzone": {
@@ -3592,51 +3598,61 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.3.0.tgz",
+      "integrity": "sha512-TM+pLwLd5DzaDlOQhqeju9H9QUFQypQiNwXQLNIxOV5r3fmKh4NTp2Av/8WmFkpCj8mejDOfp4TNxoU1zdjCkQ==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^6.2.0",
-        "@patternfly/react-styles": "^6.2.0",
-        "@patternfly/react-tokens": "^6.2.0",
+        "@patternfly/react-icons": "^6.3.0",
+        "@patternfly/react-styles": "^6.3.0",
+        "@patternfly/react-tokens": "^6.3.0",
         "focus-trap": "7.6.4",
         "react-dropzone": "^14.3.5",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.0.tgz",
+      "integrity": "sha512-W39JyqKW1UL6/YGuinDnpjbhmmLAfuxVrgDcdFBaK4D7D1iqkkqrDMV8zIzmV/RkodJ79xRnucYhYb2RukG4RA==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.0.tgz",
+      "integrity": "sha512-FvuyNsY2oN8f2dvCl4Hx8CxBWCIF3BC9JE3Ay1lCuVqY1WYkvW4AQn3/0WVRINCxB9FkQxVNkSjARdwHNCEulw==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.3.0.tgz",
+      "integrity": "sha512-klC0HKZvKhrRRJX8j1bLmfvzJyMeqpwbKeV7np9Ggvvh79IxWpBBKX2XbJkjHtl+sCwIVN1VZatil3HGba5CZQ==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.2.0",
-        "@patternfly/react-icons": "^6.2.0",
-        "@patternfly/react-styles": "^6.2.0",
-        "@patternfly/react-tokens": "^6.2.0",
+        "@patternfly/react-core": "^6.3.0",
+        "@patternfly/react-icons": "^6.3.0",
+        "@patternfly/react-styles": "^6.3.0",
+        "@patternfly/react-tokens": "^6.3.0",
         "lodash": "^4.17.21",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.2.0",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.3.0.tgz",
+      "integrity": "sha512-yWStfkbxg4RWAExFKS/JRGScyadOy35yr4DFispNeHrkZWMp4pwKf0VdwlQZ7+ZtSgEWtzzy1KFxMLmWh3mEqA==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -25522,7 +25538,7 @@
       },
       "devDependencies": {
         "@octokit/rest": "^18.0.0",
-        "@patternfly/documentation-framework": "6.8.2",
+        "@patternfly/documentation-framework": "6.16.0",
         "@patternfly/patternfly": "^6.1.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
         "@types/dom-speech-recognition": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@octokit/rest": "^18.0.0",
-    "@patternfly/documentation-framework": "6.8.2",
+    "@patternfly/documentation-framework": "6.16.0",
     "@patternfly/patternfly": "^6.1.0",
     "@patternfly/react-icons": "^6.1.0",
     "@patternfly/react-table": "^6.1.0",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "6.8.2",
+    "@patternfly/documentation-framework": "6.16.0",
     "@patternfly/patternfly": "^6.1.0",
     "@patternfly/patternfly-a11y": "^5.0.0",
     "@types/dom-speech-recognition": "^0.0.4",

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderBasic.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotHeaderBasic.tsx
@@ -17,7 +17,8 @@ import {
   ChatbotHeaderActions,
   ChatbotHeaderTitle,
   ChatbotHeaderOptionsDropdown,
-  ChatbotHeaderSelectorDropdown
+  ChatbotHeaderSelectorDropdown,
+  ChatbotHeaderNewChatButton
 } from '@patternfly/chatbot/dist/dynamic/ChatbotHeader';
 import { ChatbotDisplayMode } from '@patternfly/chatbot/dist/dynamic/Chatbot';
 import OutlinedWindowRestoreIcon from '@patternfly/react-icons/dist/esm/icons/outlined-window-restore-icon';
@@ -31,6 +32,7 @@ export const BasicDemo: FunctionComponent = () => {
   const [selectedModel, setSelectedModel] = useState('Granite Code 7B');
   const [showAll, setShowAll] = useState<boolean>(true);
   const [showMenu, setShowMenu] = useState<boolean>(true);
+  const [showNewChatButton, setShowNewChatButton] = useState<boolean>(true);
   const [showLogo, setShowLogo] = useState<boolean>(false);
   const [showCenteredLogo, setShowCenteredLogo] = useState<boolean>(true);
   const [showSelectorDropdown, setShowSelectorDropdown] = useState<boolean>(true);
@@ -58,9 +60,10 @@ export const BasicDemo: FunctionComponent = () => {
     <Stack hasGutter>
       <FormGroup role="radiogroup" isInline fieldId="header-variant-form-radio-group" label="Variant">
         <Checkbox
-          isChecked={showMenu && showCenteredLogo && showSelectorDropdown && showOptionsDropdown}
+          isChecked={showMenu && showNewChatButton && showCenteredLogo && showSelectorDropdown && showOptionsDropdown}
           onChange={() => {
             setShowMenu(true);
+            setShowNewChatButton(true);
             setShowCenteredLogo(true);
             setShowSelectorDropdown(true);
             setShowOptionsDropdown(true);
@@ -79,6 +82,16 @@ export const BasicDemo: FunctionComponent = () => {
           name="basic-inline-radio"
           label="With menu"
           id="menu"
+        />
+        <Checkbox
+          isChecked={showNewChatButton}
+          onChange={() => {
+            setShowNewChatButton(!showNewChatButton);
+            showAll && setShowAll(!showAll);
+          }}
+          name="basic-inline-radio"
+          label="With new chat button"
+          id="new-chat-button"
         />
         <Checkbox
           isChecked={showLogo}
@@ -124,9 +137,10 @@ export const BasicDemo: FunctionComponent = () => {
       </FormGroup>
 
       <ChatbotHeader>
-        {(showMenu || showLogo || showCenteredLogo) && (
+        {(showMenu || showNewChatButton || showLogo || showCenteredLogo) && (
           <ChatbotHeaderMain>
             {showMenu && <ChatbotHeaderMenu onMenuToggle={() => alert('Menu toggle clicked')} />}
+            {showNewChatButton && <ChatbotHeaderNewChatButton onClick={() => alert('New chat button clicked')} />}
             {(showLogo || showCenteredLogo) && (
               <ChatbotHeaderTitle>{showCenteredLogo ? <Bullseye>{title}</Bullseye> : title}</ChatbotHeaderTitle>
             )}

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/UI.md
@@ -61,7 +61,8 @@ ChatbotHeaderMenu,
 ChatbotHeaderActions,
 ChatbotHeaderTitle,
 ChatbotHeaderOptionsDropdown,
-ChatbotHeaderSelectorDropdown
+ChatbotHeaderSelectorDropdown,
+ChatbotHeaderNewChatButton
 } from '@patternfly/chatbot/dist/dynamic/ChatbotHeader';
 import { ChatbotFooter, ChatbotFootnote } from '@patternfly/chatbot/dist/dynamic/ChatbotFooter';
 import { MessageBar } from '@patternfly/chatbot/dist/dynamic/MessageBar';
@@ -78,6 +79,7 @@ import OutlinedWindowRestoreIcon from '@patternfly/react-icons/dist/esm/icons/ou
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import OpenDrawerRightIcon from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
+import PenToSquareIcon from '@patternfly/react-icons/dist/esm/icons/pen-to-square-icon';
 import PFHorizontalLogoColor from './PF-HorizontalLogo-Color.svg';
 import PFHorizontalLogoReverse from './PF-HorizontalLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
@@ -184,9 +186,10 @@ The ChatBot header is persistent, and contains the title for the ChatBot window,
 
 The `<ChatbotHeader>` has 2 sections:
 
-- `<ChatbotHeaderMain>` contains the title and an optional menu toggle:
+- `<ChatbotHeaderMain>` contains the title and an optional menu toggle or new chat button:
   - `<ChatbotHeaderTitle>` handles the layout and display of a title or image at different responsive sizes.
   - `<ChatbotHeaderMenu>` (optional) is placed on the left side of the header and used to toggle a chat history menu.
+  - `<ChatbotHeaderNewChatButton>` (optional) is placed on the left side of the header and used to initiate a new chat.
 - `<ChatbotHeaderActions>` contains any additional controls:
   - The `<ChatbotHeaderSelectorDropdown>` component is a standard PatternFly dropdown that matches the ChatBot styles.
   - The `<ChatbotHeaderOptionsDropdown>` component is a dropdown with a menu toggle that is intended to be used to update ChatBot settings (like the display mode).
@@ -197,6 +200,7 @@ Your `<ChatbotHeader>` code structure should look like this:
 <ChatbotHeader>
   <ChatbotHeaderMain>
     <ChatbotHeaderMenu ... />
+    <ChatbotHeaderNewChatButton ... />
     <ChatbotHeaderTitle ... />
   </ChatbotHeaderMain>
   <ChatbotHeaderActions>
@@ -221,6 +225,7 @@ There are a variety of options and customizations you can make to the header, to
 In this example, select the respective checkbox to toggle these features:
 
 - **Menu:** Users can select the menu toggle to open a menu of additional options or actions.
+- **New chat button:** Used to start a new chat session. The header button can be used in addition to or in place of a new chat button within the [conversation history drawer](/patternfly-ai/chatbot/ui/#drawer-with-search-and-new-chat-button).
 - **Left-aligned logo**
 - **Centered logo**
 - **Selector dropdown:** Users can choose from preselected options in a dropdown menu. For example, they can toggle between AI models.

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.md
@@ -45,7 +45,7 @@ ChatbotHeaderTitle,
 ChatbotHeaderActions,
 ChatbotHeaderSelectorDropdown,
 ChatbotHeaderOptionsDropdown,
-ChatbotHeaderCloseButton
+ChatbotHeaderCloseButton,
 } from '@patternfly/chatbot/dist/dynamic/ChatbotHeader';
 
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -38,7 +38,7 @@ import {
   ButtonProps
 } from '@patternfly/react-core';
 
-import { OutlinedClockIcon, OutlinedCommentAltIcon } from '@patternfly/react-icons';
+import { OutlinedClockIcon, OutlinedCommentAltIcon, PenToSquareIcon } from '@patternfly/react-icons';
 import { ChatbotDisplayMode } from '../Chatbot/Chatbot';
 import ConversationHistoryDropdown from './ChatbotConversationHistoryDropdown';
 import LoadingState from './LoadingState';
@@ -262,7 +262,12 @@ export const ChatbotConversationHistoryNav: FunctionComponent<ChatbotConversatio
           >
             <DrawerCloseButton onClick={onDrawerToggle} {...drawerCloseButtonProps} />
             {onNewChat && (
-              <Button size={isCompact ? 'sm' : undefined} onClick={onNewChat} {...newChatButtonProps}>
+              <Button
+                size={isCompact ? 'sm' : undefined}
+                onClick={onNewChat}
+                icon={<PenToSquareIcon />}
+                {...newChatButtonProps}
+              >
                 {newChatButtonText}
               </Button>
             )}

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderNewChatButton.test.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderNewChatButton.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChatbotHeaderNewChatButton } from './ChatbotHeaderNewChatButton';
+import '@testing-library/jest-dom';
+
+describe('ChatbotHeaderNewChatButton', () => {
+  it('should render ChatbotHeaderNewChatButton', () => {
+    const { container } = render(
+      <ChatbotHeaderNewChatButton className="custom-header-new-chat-button" onClick={jest.fn()} />
+    );
+
+    expect(container.querySelector('.custom-header-new-chat-button')).toBeTruthy();
+  });
+
+  it('should call onClick handler when new chat button is pressed', () => {
+    const onClick = jest.fn();
+    render(<ChatbotHeaderNewChatButton className="custom-header-new-chat-button" onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should render button with isCompact', () => {
+    render(<ChatbotHeaderNewChatButton data-testid="new-chat-button" onClick={jest.fn()} isCompact />);
+    expect(screen.getByTestId('new-chat-button')).toHaveClass('pf-m-compact');
+  });
+});

--- a/packages/module/src/ChatbotHeader/ChatbotHeaderNewChatButton.tsx
+++ b/packages/module/src/ChatbotHeader/ChatbotHeaderNewChatButton.tsx
@@ -1,0 +1,64 @@
+import type { Ref, FunctionComponent } from 'react';
+import { forwardRef } from 'react';
+
+import { Button, ButtonProps, Icon, Tooltip, TooltipProps } from '@patternfly/react-core';
+import { PenToSquareIcon } from '@patternfly/react-icons/dist/esm/icons/pen-to-square-icon';
+
+export interface ChatbotHeaderNewChatButtonProps extends ButtonProps {
+  /** Callback function for when button is clicked */
+  onClick: () => void;
+  /** Custom classname for the header component */
+  className?: string;
+  /** Props spread to the PF Tooltip component wrapping the display mode dropdown */
+  tooltipProps?: TooltipProps;
+  /** Aria label for menu */
+  menuAriaLabel?: string;
+  /** Ref applied to menu */
+  innerRef?: React.Ref<HTMLButtonElement>;
+  /** Content used in tooltip */
+  tooltipContent?: string;
+  /** Sets button to compact styling. */
+  isCompact?: boolean;
+}
+
+const ChatbotHeaderNewChatButtonBase: FunctionComponent<ChatbotHeaderNewChatButtonProps> = ({
+  className,
+  onClick,
+  tooltipProps,
+  menuAriaLabel = 'New chat',
+  innerRef,
+  tooltipContent = 'New chat',
+  isCompact,
+  ...props
+}: ChatbotHeaderNewChatButtonProps) => (
+  <div className={`pf-chatbot__menu${className ? ` ${className}` : ''}`}>
+    <Tooltip
+      content={tooltipContent}
+      position="bottom"
+      // prevents VO announcements of both aria label and tooltip
+      aria="none"
+      {...tooltipProps}
+    >
+      <Button
+        className={`pf-chatbot__button--toggle-menu ${isCompact ? 'pf-m-compact' : ''}`}
+        variant="plain"
+        onClick={onClick}
+        aria-label={menuAriaLabel}
+        ref={innerRef}
+        icon={
+          <Icon size={isCompact ? 'lg' : 'xl'} isInline>
+            <PenToSquareIcon />
+          </Icon>
+        }
+        size={isCompact ? 'sm' : undefined}
+        {...props}
+      />
+    </Tooltip>
+  </div>
+);
+
+export const ChatbotHeaderNewChatButton = forwardRef(
+  (props: ChatbotHeaderNewChatButtonProps, ref: Ref<HTMLButtonElement>) => (
+    <ChatbotHeaderNewChatButtonBase innerRef={ref} {...props} />
+  )
+);

--- a/packages/module/src/ChatbotHeader/index.ts
+++ b/packages/module/src/ChatbotHeader/index.ts
@@ -8,3 +8,4 @@ export * from './ChatbotHeaderTitle';
 export * from './ChatbotHeaderOptionsDropdown';
 export * from './ChatbotHeaderSelectorDropdown';
 export * from './ChatbotHeaderCloseButton';
+export * from './ChatbotHeaderNewChatButton';

--- a/packages/module/src/FileDetails/__snapshots__/FileDetails.test.tsx.snap
+++ b/packages/module/src/FileDetails/__snapshots__/FileDetails.test.tsx.snap
@@ -48,19 +48,16 @@ exports[`FileDetails should render file details 1`] = `
         <span
           class="pf-chatbot__code-fileName"
         >
-          <div
-            style="display: contents;"
+          <span
+            class="pf-v6-c-truncate"
+            tabindex="0"
           >
             <span
-              class="pf-v6-c-truncate"
+              class="pf-v6-c-truncate__start"
             >
-              <span
-                class="pf-v6-c-truncate__start"
-              >
-                test
-              </span>
+              test
             </span>
-          </div>
+          </span>
         </span>
       </div>
       <div

--- a/packages/module/src/FileDetailsLabel/__snapshots__/FileDetailsLabel.test.tsx.snap
+++ b/packages/module/src/FileDetailsLabel/__snapshots__/FileDetailsLabel.test.tsx.snap
@@ -60,19 +60,16 @@ exports[`FileDetailsLabel should render file details label 1`] = `
                 <span
                   class="pf-chatbot__code-fileName"
                 >
-                  <div
-                    style="display: contents;"
+                  <span
+                    class="pf-v6-c-truncate"
+                    tabindex="0"
                   >
                     <span
-                      class="pf-v6-c-truncate"
+                      class="pf-v6-c-truncate__start"
                     >
-                      <span
-                        class="pf-v6-c-truncate__start"
-                      >
-                        test
-                      </span>
+                      test
                     </span>
-                  </div>
+                  </span>
                 </span>
               </div>
               <div


### PR DESCRIPTION
Closes #509. Updated @patternfly/documentation-framework to 6.16.0 for icon. Buttons in the header and basic chatbot demos, when clicked, do not have functionality as of this moment. If needed, these buttons can also be added to other demos.