### PR TITLE
feat(ToolResponse): Add component

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
@@ -1,0 +1,141 @@
+import { useState, FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
+import Message from '@patternfly/chatbot/dist/dynamic/Message';
+import patternflyAvatar from './patternfly_avatar.jpg';
+import { CopyIcon, WrenchIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+  ExpandableSectionVariant,
+  Flex,
+  FlexItem,
+  Label
+} from '@patternfly/react-core';
+
+export const MessageWithToolResponseExample: FunctionComponent = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const onToggle = (_event: ReactMouseEvent, isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+  };
+
+  return (
+    <Message
+      name="Bot"
+      role="bot"
+      avatar={patternflyAvatar}
+      content="This example has a body description that's within the recommended limit of 2 lines:"
+      toolResponse={{
+        collapsedToggleText: 'Tool response: Name',
+        expandedToggleText: 'Tool response: Name',
+        subheading: 'Thought for 3 seconds',
+        body: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        cardTitle: (
+          <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+            <FlexItem>
+              <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }}>
+                <FlexItem grow={{ default: 'grow' }}>
+                  <Flex gap={{ default: 'gapXs' }}>
+                    <FlexItem>
+                      <WrenchIcon style={{ color: 'var(--pf-t--global--icon--color--brand--default' }} />
+                    </FlexItem>
+                    <FlexItem>Tool name</FlexItem>
+                  </Flex>
+                </FlexItem>
+                <FlexItem>
+                  <Flex gap={{ default: 'gapSm' }} style={{ fontSize: '12px', fontWeight: '400' }}>
+                    <FlexItem>Execution time:</FlexItem>
+                    <FlexItem>0.12s</FlexItem>
+                  </Flex>
+                </FlexItem>
+              </Flex>
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="plain"
+                aria-label="Copy tool response to clipboard"
+                icon={<CopyIcon style={{ color: 'var(--pf-t--global--icon--color--subtle)' }} />}
+              ></Button>
+            </FlexItem>
+          </Flex>
+        ),
+        cardBody: (
+          <>
+            <DescriptionList
+              style={{ '--pf-v6-c-description-list--RowGap': 'var(--pf-t--global--spacer--md)' } as any}
+              aria-label="Tool response"
+            >
+              <DescriptionListGroup
+                style={{ '--pf-v6-c-description-list__group--RowGap': 'var(--pf-t--global--spacer--xs)' } as any}
+              >
+                <DescriptionListTerm>Parameters</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Flex direction={{ default: 'column' }}>
+                    <FlexItem>Optional description text goes here</FlexItem>
+                    <FlexItem>
+                      <Flex gap={{ default: 'gapSm' }}>
+                        <FlexItem>
+                          <Label variant="outline" color="blue">
+                            type
+                          </Label>
+                        </FlexItem>
+                        <FlexItem>
+                          <Label variant="outline" color="blue">
+                            properties
+                          </Label>
+                        </FlexItem>
+                        <FlexItem>
+                          <Label variant="outline" color="blue">
+                            label
+                          </Label>
+                        </FlexItem>
+                        <FlexItem>
+                          <Label variant="outline" color="blue">
+                            label
+                          </Label>
+                        </FlexItem>
+                      </Flex>
+                    </FlexItem>
+                  </Flex>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup
+                style={{ '--pf-v6-c-description-list__group--RowGap': 'var(--pf-t--global--spacer--xs)' } as any}
+              >
+                <DescriptionListTerm>Response</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <ExpandableSection
+                    variant={ExpandableSectionVariant.truncate}
+                    toggleText={isExpanded ? 'show less' : 'show more'}
+                    onToggle={onToggle}
+                    isExpanded={isExpanded}
+                    style={
+                      {
+                        '--pf-v6-c-expandable-section__content--Opacity': '1',
+                        '--pf-v6-c-expandable-section__content--PaddingInlineStart': 0,
+                        '--pf-v6-c-expandable-section__content--TranslateY': 0,
+                        '--pf-v6-c-expandable-section--m-expand-top__content--TranslateY': 0
+                      } as any
+                    }
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec dignissim turpis, et tristique
+                    purus. Phasellus efficitur ante quis dolor viverra imperdiet. Orci varius natoque penatibus et
+                    magnis dis parturient montes, nascetur ridiculus mus. Pellentesque laoreet, sem ac elementum semper,
+                    lectus mauris vestibulum nulla, eget volutpat massa neque vel turpis. Donec finibus enim eu leo
+                    accumsan consectetur. Praesent massa diam, tincidunt eu dui ac, ullamcorper elementum est. Phasellus
+                    metus felis, venenatis vitae semper nec, porta a metus. Vestibulum justo nisi, imperdiet id eleifend
+                    at, varius nec lorem. Fusce porttitor mollis nibh, ut elementum ante commodo tincidunt. Integer
+                    tincidunt at ipsum non aliquet.
+                  </ExpandableSection>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </>
+        )
+      }}
+    />
+  );
+};

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
@@ -29,8 +29,7 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
       avatar={patternflyAvatar}
       content="This example has a body description that's within the recommended limit of 2 lines:"
       toolResponse={{
-        collapsedToggleText: 'Tool response: toolName',
-        expandedToggleText: 'Tool response: toolName',
+        toggleContent: 'Tool response: toolName',
         subheading: 'Thought for 3 seconds',
         body: "Here's the summary for your toolName response:",
         cardTitle: (
@@ -109,7 +108,8 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
                 <DescriptionListDescription>
                   <ExpandableSection
                     variant={ExpandableSectionVariant.truncate}
-                    toggleText={isExpanded ? 'show less' : 'show more'}
+                    toggleTextExpanded="show less of response"
+                    toggleTextCollapsed="show more of response"
                     onToggle={onToggle}
                     isExpanded={isExpanded}
                     style={

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
@@ -29,10 +29,10 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
       avatar={patternflyAvatar}
       content="This example has a body description that's within the recommended limit of 2 lines:"
       toolResponse={{
-        collapsedToggleText: 'Tool response: Name',
-        expandedToggleText: 'Tool response: Name',
+        collapsedToggleText: 'Tool response: toolName',
+        expandedToggleText: 'Tool response: toolName',
         subheading: 'Thought for 3 seconds',
-        body: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+        body: "Here's the summary for your Tool name response:",
         cardTitle: (
           <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
             <FlexItem>
@@ -48,7 +48,7 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
                 <FlexItem>
                   <Flex gap={{ default: 'gapSm' }} style={{ fontSize: '12px', fontWeight: '400' }}>
                     <FlexItem>Execution time:</FlexItem>
-                    <FlexItem>0.12s</FlexItem>
+                    <FlexItem>0.12 seconds</FlexItem>
                   </Flex>
                 </FlexItem>
               </Flex>
@@ -74,7 +74,7 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
                 <DescriptionListTerm>Parameters</DescriptionListTerm>
                 <DescriptionListDescription>
                   <Flex direction={{ default: 'column' }}>
-                    <FlexItem>Optional description text goes here</FlexItem>
+                    <FlexItem>Optional description text for parameters.</FlexItem>
                     <FlexItem>
                       <Flex gap={{ default: 'gapSm' }}>
                         <FlexItem>
@@ -121,14 +121,8 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
                       } as any
                     }
                   >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec dignissim turpis, et tristique
-                    purus. Phasellus efficitur ante quis dolor viverra imperdiet. Orci varius natoque penatibus et
-                    magnis dis parturient montes, nascetur ridiculus mus. Pellentesque laoreet, sem ac elementum semper,
-                    lectus mauris vestibulum nulla, eget volutpat massa neque vel turpis. Donec finibus enim eu leo
-                    accumsan consectetur. Praesent massa diam, tincidunt eu dui ac, ullamcorper elementum est. Phasellus
-                    metus felis, venenatis vitae semper nec, porta a metus. Vestibulum justo nisi, imperdiet id eleifend
-                    at, varius nec lorem. Fusce porttitor mollis nibh, ut elementum ante commodo tincidunt. Integer
-                    tincidunt at ipsum non aliquet.
+                    Descriptive text about the tool response, including completion status, details on the data that was
+                    processed, or anything else relevant to the use case.
                   </ExpandableSection>
                 </DescriptionListDescription>
               </DescriptionListGroup>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
@@ -32,7 +32,7 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
         collapsedToggleText: 'Tool response: toolName',
         expandedToggleText: 'Tool response: toolName',
         subheading: 'Thought for 3 seconds',
-        body: "Here's the summary for your Tool name response:",
+        body: "Here's the summary for your toolName response:",
         cardTitle: (
           <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
             <FlexItem>
@@ -42,7 +42,7 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
                     <FlexItem>
                       <WrenchIcon style={{ color: 'var(--pf-t--global--icon--color--brand--default' }} />
                     </FlexItem>
-                    <FlexItem>Tool name</FlexItem>
+                    <FlexItem>toolName</FlexItem>
                   </Flex>
                 </FlexItem>
                 <FlexItem>

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
@@ -34,7 +34,7 @@ import Message from '@patternfly/chatbot/dist/dynamic/Message';
 import MessageDivider from '@patternfly/chatbot/dist/dynamic/MessageDivider';
 import { rehypeCodeBlockToggle } from '@patternfly/chatbot/dist/esm/Message/Plugins/rehypeCodeBlockToggle';
 import SourcesCard from '@patternfly/chatbot/dist/dynamic/SourcesCard';
-import { ArrowCircleDownIcon, ArrowRightIcon, CheckCircleIcon, CubeIcon, CubesIcon, DownloadIcon, InfoCircleIcon, OutlinedQuestionCircleIcon, RedoIcon, RobotIcon } from '@patternfly/react-icons';
+import { ArrowCircleDownIcon, ArrowRightIcon, CheckCircleIcon, CopyIcon, CubeIcon, CubesIcon, DownloadIcon, InfoCircleIcon, OutlinedQuestionCircleIcon, RedoIcon, RobotIcon, WrenchIcon } from '@patternfly/react-icons';
 import patternflyAvatar from './patternfly_avatar.jpg';
 import AttachmentEdit from '@patternfly/chatbot/dist/dynamic/AttachmentEdit';
 import FileDetails from '@patternfly/chatbot/dist/dynamic/FileDetails';
@@ -175,6 +175,14 @@ If a source will open outside of the ChatBot window, add an external link icon v
 The API for a source requires a link at minimum, but we strongly recommend providing a more descriptive title and body description so users have enough context. For the best clarity and readability, we strongly recommend limiting the title to 1 line and the body to 2 lines. If the body description is more than 2 lines, use the "long sources" or "very long sources" variant.
 
 ```js file="./MessageWithSources.tsx"
+
+```
+
+### Messages with tool responses
+
+If you are using [model context protocol (MCP)](https://www.redhat.com/en/blog/model-context-protocol-discover-missing-link-ai-integration), you may find it useful to display information on tool responses as part of a message. Passing `toolResponse` to `<Message>` allows you to display a card with an optional subheading and body, as well as custom card content. Content is intentionally left fully customizable for now as this is an evolving area.
+
+```js file="./MessageWithToolResponse.tsx"
 
 ```
 

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -683,8 +683,7 @@ describe('Message', () => {
         name="User"
         content="Hi"
         toolResponse={{
-          collapsedToggleText: 'Tool response: Name',
-          expandedToggleText: 'Tool response: Name',
+          toggleContent: 'Tool response: Name',
           subheading: 'Thought for 3 seconds',
           body: 'Lorem ipsum dolor sit amet',
           cardTitle: 'Card title',

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -675,6 +675,29 @@ describe('Message', () => {
     );
     expect(screen.getAllByRole('img')[1]).toHaveAttribute('src', 'test.png');
   });
+  it('should handle tool response correctly', async () => {
+    render(
+      <Message
+        avatar="./img"
+        role="user"
+        name="User"
+        content="Hi"
+        toolResponse={{
+          collapsedToggleText: 'Tool response: Name',
+          expandedToggleText: 'Tool response: Name',
+          subheading: 'Thought for 3 seconds',
+          body: 'Lorem ipsum dolor sit amet',
+          cardTitle: 'Card title',
+          cardBody: 'Card body'
+        }}
+      />
+    );
+    expect(screen.getByRole('button', { name: /Tool response: Name/i })).toBeTruthy();
+    expect(screen.getByText('Thought for 3 seconds')).toBeTruthy();
+    expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeTruthy();
+    expect(screen.getByText('Card title')).toBeTruthy();
+    expect(screen.getByText('Card body')).toBeTruthy();
+  });
   it('should handle block quote correctly', () => {
     render(<Message avatar="./img" role="user" name="User" content={BLOCK_QUOTES} />);
     expect(screen.getByText(/Blockquotes can also be nested.../)).toBeTruthy();

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -49,6 +49,7 @@ import LinkMessage from './LinkMessage/LinkMessage';
 import ErrorMessage from './ErrorMessage/ErrorMessage';
 import MessageInput from './MessageInput';
 import { rehypeMoveImagesOutOfParagraphs } from './Plugins/rehypeMoveImagesOutOfParagraphs';
+import ToolResponse, { ToolResponseProps } from '../ToolResponse';
 
 export interface MessageAttachment {
   /** Name of file attached to the message */
@@ -189,6 +190,8 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   isMarkdownDisabled?: boolean;
   /** Allows passing additional props down to markdown parser react-markdown, such as allowedElements and disallowedElements. See https://github.com/remarkjs/react-markdown?tab=readme-ov-file#options for options */
   reactMarkdownProps?: Options;
+  /** Props for tool response card */
+  toolResponse?: ToolResponseProps;
 }
 
 export const MessageBase: FunctionComponent<MessageProps> = ({
@@ -230,6 +233,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
   isCompact,
   isMarkdownDisabled,
   reactMarkdownProps,
+  toolResponse,
   ...props
 }: MessageProps) => {
   const [messageText, setMessageText] = useState(content);
@@ -376,6 +380,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
           <div className="pf-chatbot__message-and-actions">
             {renderMessage()}
             {afterMainContent && <>{afterMainContent}</>}
+            {toolResponse && <ToolResponse {...toolResponse} />}
             {!isLoading && sources && <SourcesCard {...sources} isCompact={isCompact} />}
             {quickStarts && quickStarts.quickStart && (
               <QuickStartTile

--- a/packages/module/src/ToolResponse/ToolResponse.scss
+++ b/packages/module/src/ToolResponse/ToolResponse.scss
@@ -20,6 +20,7 @@
 
 .pf-chatbot__tool-response-body {
   color: var(--pf-t--global--text--color--subtle);
+  margin-block-end: var(--pf-t--global--spacer--xs);
 }
 
 .pf-chatbot__tool-response-card {

--- a/packages/module/src/ToolResponse/ToolResponse.scss
+++ b/packages/module/src/ToolResponse/ToolResponse.scss
@@ -1,5 +1,6 @@
 .pf-chatbot__tool-response {
   --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  overflow: unset;
 }
 
 .pf-chatbot__tool-response-expandable-section {

--- a/packages/module/src/ToolResponse/ToolResponse.scss
+++ b/packages/module/src/ToolResponse/ToolResponse.scss
@@ -1,0 +1,34 @@
+.pf-chatbot__tool-response {
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+}
+
+.pf-chatbot__tool-response-expandable-section {
+  --pf-v6-c-expandable-section--Gap: var(--pf-t--global--spacer--xs);
+}
+
+.pf-chatbot__tool-response-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--xs);
+}
+
+.pf-chatbot__tool-response-subheading {
+  font-size: var(--pf-t--global--font--size--body--sm);
+  font-weight: var(--pf-t--global--font--weight--body--default);
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.pf-chatbot__tool-response-body {
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.pf-chatbot__tool-response-card {
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  --pf-v6-c-card--first-child--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+  --pf-v6-c-card__title--not--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
+  --pf-v6-c-card--c-divider--child--PaddingBlockStart: var(--pf-t--global--spacer--sm);
+
+  .pf-v6-c-divider {
+    --pf-v6-c-divider--Color: var(--pf-t--global--border--color--control--read-only);
+  }
+}

--- a/packages/module/src/ToolResponse/ToolResponse.test.tsx
+++ b/packages/module/src/ToolResponse/ToolResponse.test.tsx
@@ -1,12 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ToolResponse from './ToolResponse';
 
 describe('ToolResponse', () => {
   const defaultProps = {
-    collapsedToggleText: 'Show details',
-    expandedToggleText: 'Hide details',
+    toggleContent: 'Tool response: toolName',
     cardTitle: 'Title',
     cardBody: 'Body'
   };
@@ -15,28 +13,7 @@ describe('ToolResponse', () => {
     render(<ToolResponse {...defaultProps} />);
     expect(screen.getByText('Title')).toBeTruthy();
     expect(screen.getByText('Body')).toBeTruthy();
-    expect(screen.getByText('Hide details')).toBeTruthy();
-  });
-
-  it('should render expanded by default', () => {
-    render(<ToolResponse {...defaultProps} />);
-    expect(screen.getByText('Hide details')).toBeTruthy();
-    expect(screen.queryByText('Show details')).toBeFalsy();
-  });
-
-  it('should toggle between expanded and collapsed states', async () => {
-    const user = userEvent.setup();
-    render(<ToolResponse {...defaultProps} />);
-    const toggleButton = screen.getByRole('button', { name: /Hide details/i });
-    expect(screen.getByText('Hide details')).toBeTruthy();
-    await user.click(toggleButton);
-    expect(screen.getByText('Show details')).toBeTruthy();
-    expect(screen.queryByText('Hide details')).toBeFalsy();
-
-    // Click to expand again
-    await user.click(screen.getByRole('button', { name: /Show details/i }));
-    expect(screen.getByText('Hide details')).toBeTruthy();
-    expect(screen.queryByText('Show details')).toBeFalsy();
+    expect(screen.getByText('Tool response: toolName')).toBeTruthy();
   });
 
   it('should render subheading when provided', () => {

--- a/packages/module/src/ToolResponse/ToolResponse.test.tsx
+++ b/packages/module/src/ToolResponse/ToolResponse.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ToolResponse from './ToolResponse';
+
+describe('ToolResponse', () => {
+  const defaultProps = {
+    collapsedToggleText: 'Show details',
+    expandedToggleText: 'Hide details',
+    cardTitle: 'Title',
+    cardBody: 'Body'
+  };
+
+  it('should render with required props only', () => {
+    render(<ToolResponse {...defaultProps} />);
+    expect(screen.getByText('Title')).toBeTruthy();
+    expect(screen.getByText('Body')).toBeTruthy();
+    expect(screen.getByText('Hide details')).toBeTruthy();
+  });
+
+  it('should render expanded by default', () => {
+    render(<ToolResponse {...defaultProps} />);
+    expect(screen.getByText('Hide details')).toBeTruthy();
+    expect(screen.queryByText('Show details')).toBeFalsy();
+  });
+
+  it('should toggle between expanded and collapsed states', async () => {
+    const user = userEvent.setup();
+    render(<ToolResponse {...defaultProps} />);
+    const toggleButton = screen.getByRole('button', { name: /Hide details/i });
+    expect(screen.getByText('Hide details')).toBeTruthy();
+    await user.click(toggleButton);
+    expect(screen.getByText('Show details')).toBeTruthy();
+    expect(screen.queryByText('Hide details')).toBeFalsy();
+
+    // Click to expand again
+    await user.click(screen.getByRole('button', { name: /Show details/i }));
+    expect(screen.getByText('Hide details')).toBeTruthy();
+    expect(screen.queryByText('Show details')).toBeFalsy();
+  });
+
+  it('should render subheading when provided', () => {
+    const subheading = 'Tool execution result';
+    render(<ToolResponse {...defaultProps} subheading={subheading} />);
+    expect(screen.getByText(subheading)).toBeTruthy();
+  });
+
+  it('should render body content when provided', () => {
+    const body = 'This is the tool response body content';
+    render(<ToolResponse {...defaultProps} body={body} />);
+    expect(screen.getByText(body)).toBeTruthy();
+  });
+
+  it('should render with complex content including React elements', () => {
+    const body = (
+      <div>
+        <p>Complex body content</p>
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+        </ul>
+      </div>
+    );
+    const cardTitle = <strong>API Response</strong>;
+    const cardBody = (
+      <div>
+        <code>{"{ status: 'success' }"}</code>
+      </div>
+    );
+
+    render(<ToolResponse {...defaultProps} body={body} cardTitle={cardTitle} cardBody={cardBody} />);
+    expect(screen.getByText('Complex body content')).toBeTruthy();
+    expect(screen.getByText('Item 1')).toBeTruthy();
+    expect(screen.getByText('Item 2')).toBeTruthy();
+    expect(screen.getByText('API Response')).toBeTruthy();
+    expect(screen.getByText("{ status: 'success' }")).toBeTruthy();
+  });
+
+  it('should apply custom className from cardProps', () => {
+    const { container } = render(
+      <ToolResponse {...defaultProps} cardProps={{ className: 'custom-tool-response-class' }} />
+    );
+    expect(container.querySelector('.custom-tool-response-class')).toBeTruthy();
+  });
+
+  it('should pass through expandableSectionProps', () => {
+    render(<ToolResponse {...defaultProps} expandableSectionProps={{ className: 'custom-expandable-class' }} />);
+    expect(document.querySelector('.custom-expandable-class')).toBeTruthy();
+  });
+
+  it('should pass through toolResponseCardProps', () => {
+    render(<ToolResponse {...defaultProps} toolResponseCardProps={{ className: 'custom-card-class' }} />);
+    expect(document.querySelector('.custom-card-class')).toBeTruthy();
+  });
+
+  it('should not render subheading span when subheading is not provided', () => {
+    const { container } = render(<ToolResponse {...defaultProps} />);
+    const subheadingContainer = container.querySelector('.pf-chatbot__tool-response-subheading');
+    expect(subheadingContainer).toBeFalsy();
+  });
+});

--- a/packages/module/src/ToolResponse/ToolResponse.tsx
+++ b/packages/module/src/ToolResponse/ToolResponse.tsx
@@ -1,0 +1,98 @@
+// ============================================================================
+// Tool Response Card
+// ============================================================================
+import {
+  Card,
+  CardBody,
+  CardBodyProps,
+  CardProps,
+  CardTitle,
+  CardTitleProps,
+  Divider,
+  DividerProps,
+  ExpandableSection,
+  ExpandableSectionProps
+} from '@patternfly/react-core';
+import { useState, type FunctionComponent } from 'react';
+
+export interface ToolResponseProps {
+  /** Toggle text shown on expandable section when it is collapsed */
+  collapsedToggleText: string;
+  /** Toggle text shown on expandable section when it is expanded */
+  expandedToggleText: string;
+  /** Additional props passed to expandable section */
+  expandableSectionProps?: Omit<ExpandableSectionProps, 'ref'>;
+  /** Subheading rendered inside expandable section */
+  subheading?: string;
+  /** Body text rendered inside expandable section */
+  body?: React.ReactNode | string;
+  /** Content passed into tool response card body */
+  cardBody: React.ReactNode;
+  /** Content passed into tool response card title */
+  cardTitle: React.ReactNode;
+  /** Additional props passed to main card */
+  cardProps?: CardProps;
+  /** Additional props passed to main card body */
+  cardBodyProps?: CardBodyProps;
+  /** Additional props passed to tool response card */
+  toolResponseCardProps?: CardProps;
+  /** Additional props passed to tool response card body */
+  toolResponseCardBodyProps?: CardBodyProps;
+  /** Additional props passed to tool response card divider */
+  toolResponseCardDividerProps?: DividerProps;
+  /** Additional props passed to tool response card title */
+  toolResponseCardTitleProps?: CardTitleProps;
+}
+
+export const ToolResponse: FunctionComponent<ToolResponseProps> = ({
+  body,
+  cardProps,
+  collapsedToggleText,
+  expandableSectionProps,
+  expandedToggleText,
+  subheading,
+  cardBody,
+  cardTitle,
+  cardBodyProps,
+  toolResponseCardBodyProps,
+  toolResponseCardDividerProps,
+  toolResponseCardProps,
+  toolResponseCardTitleProps
+}: ToolResponseProps) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+  };
+
+  return (
+    <Card isCompact className="pf-chatbot__tool-response" {...cardProps}>
+      <CardBody {...cardBodyProps}>
+        <ExpandableSection
+          toggleText={isExpanded ? expandedToggleText : collapsedToggleText}
+          onToggle={onToggle}
+          isExpanded={isExpanded}
+          isIndented
+          className="pf-chatbot__tool-response-expandable-section"
+          {...expandableSectionProps}
+        >
+          <div className="pf-chatbot__tool-response-section">
+            {subheading && (
+              <div className="pf-chatbot__tool-response-subheading">
+                <span>{subheading}</span>
+              </div>
+            )}
+            {body && <div className="pf-chatbot__tool-response-body">{body}</div>}
+            <Card isCompact className="pf-chatbot__tool-response-card" {...toolResponseCardProps}>
+              <CardTitle {...toolResponseCardTitleProps}>{cardTitle}</CardTitle>
+              <Divider {...toolResponseCardDividerProps} />
+              <CardBody {...toolResponseCardBodyProps}>{cardBody}</CardBody>
+            </Card>
+          </div>
+        </ExpandableSection>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ToolResponse;

--- a/packages/module/src/ToolResponse/ToolResponse.tsx
+++ b/packages/module/src/ToolResponse/ToolResponse.tsx
@@ -16,10 +16,8 @@ import {
 import { useState, type FunctionComponent } from 'react';
 
 export interface ToolResponseProps {
-  /** Toggle text shown on expandable section when it is collapsed */
-  collapsedToggleText: string;
-  /** Toggle text shown on expandable section when it is expanded */
-  expandedToggleText: string;
+  /** Toggle content shown for expandable section */
+  toggleContent: React.ReactNode;
   /** Additional props passed to expandable section */
   expandableSectionProps?: Omit<ExpandableSectionProps, 'ref'>;
   /** Subheading rendered inside expandable section */
@@ -47,13 +45,12 @@ export interface ToolResponseProps {
 export const ToolResponse: FunctionComponent<ToolResponseProps> = ({
   body,
   cardProps,
-  collapsedToggleText,
   expandableSectionProps,
-  expandedToggleText,
   subheading,
   cardBody,
   cardTitle,
   cardBodyProps,
+  toggleContent,
   toolResponseCardBodyProps,
   toolResponseCardDividerProps,
   toolResponseCardProps,
@@ -69,7 +66,7 @@ export const ToolResponse: FunctionComponent<ToolResponseProps> = ({
     <Card isCompact className="pf-chatbot__tool-response" {...cardProps}>
       <CardBody {...cardBodyProps}>
         <ExpandableSection
-          toggleText={isExpanded ? expandedToggleText : collapsedToggleText}
+          toggleContent={toggleContent}
           onToggle={onToggle}
           isExpanded={isExpanded}
           isIndented

--- a/packages/module/src/ToolResponse/index.ts
+++ b/packages/module/src/ToolResponse/index.ts
@@ -1,0 +1,3 @@
+export { default } from './ToolResponse';
+
+export * from './ToolResponse';

--- a/packages/module/src/index.ts
+++ b/packages/module/src/index.ts
@@ -84,5 +84,8 @@ export * from './SourcesCard';
 export { default as TermsOfUse } from './TermsOfUse';
 export * from './TermsOfUse';
 
+export { default as ToolResponse } from './ToolResponse';
+export * from './ToolResponse';
+
 export { default as tracking } from './tracking';
 export * from './tracking';

--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -33,6 +33,7 @@
 @import './SourcesCard/SourcesCard.scss';
 @import './SourceDetailsMenuItem/SourceDetailsMenuItem';
 @import './TermsOfUse/TermsOfUse';
+@import './ToolResponse/ToolResponse';
 
 .ws-full-page-utils {
   left: 0 !important;


### PR DESCRIPTION
Added new tool response component with demo and tests.

Here are some screenshots in situ:
<img width="1480" height="682" alt="Screenshot 2025-08-28 at 9 53 44 AM" src="https://github.com/user-attachments/assets/81222a28-f198-4e06-a972-5047492e9f23" />
<img width="489" height="692" alt="Screenshot 2025-08-28 at 9 53 21 AM" src="https://github.com/user-attachments/assets/3922a286-d400-4009-8e7e-ebfb70986c32" />
<img width="525" height="590" alt="Screenshot 2025-08-28 at 9 53 32 AM" src="https://github.com/user-attachments/assets/05648e87-f6b1-4f6d-84ea-39602227412d" />


Demo: https://chatbot-pr-chatbot-662.surge.sh/patternfly-ai/chatbot/messages#messages-with-tool-responses