### PR TITLE
chore: remove theme switcher overrides

### DIFF
--- a/packages/module/src/main.scss
+++ b/packages/module/src/main.scss
@@ -39,11 +39,6 @@
 @import './ToolResponse/ToolResponse';
 @import './ToolCall/ToolCall';
 
-.ws-full-page-utils {
-  left: 0 !important;
-  right: auto !important;
-}
-
 // hide from view but not assistive technologies
 // https://css-tricks.com/inclusively-hidden/
 .pf-chatbot-m-hidden {


### PR DESCRIPTION
Removes the theme switcher overrides that put the menu in the bottom/left. docs-framework has been updated so it's in the bottom/left by default.