### PR TITLE
fix(Message): Adjust width of footnote backref links

### DIFF
--- a/packages/module/src/Message/TextMessage/TextMessage.scss
+++ b/packages/module/src/Message/TextMessage/TextMessage.scss
@@ -71,6 +71,12 @@ li[id*='user-content-fn-']:has(> span > span > .pf-chatbot__message-text + .pf-c
   margin-block-end: var(--pf-t--global--spacer--md);
 }
 
+.pf-chatbot__message-text.footnotes {
+  .data-footnote-backref {
+    width: fit-content;
+  }
+}
+
 .pf-chatbot__message--user {
   .pf-chatbot__message-text {
     background-color: var(--pf-t--global--color--brand--default);


### PR DESCRIPTION
Made width of link smaller.

<img width="712" height="408" alt="Screenshot 2025-09-19 at 2 29 49 PM" src="https://github.com/user-attachments/assets/7c1d17b6-1b95-439b-9c6f-f277bb1b62af" />


https://chatbot-pr-chatbot-683.surge.sh/patternfly-ai/chatbot/messages#user-messages