### PR TITLE
feat(MessageLoading): Add support for high contrast

### DIFF
--- a/packages/module/src/Message/MessageLoading.scss
+++ b/packages/module/src/Message/MessageLoading.scss
@@ -6,6 +6,9 @@
   padding: var(--pf-t--global--spacer--sm);
   background-color: var(--pf-t--global--background--color--tertiary--default);
   border-radius: var(--pf-t--global--border--radius--small);
+  // for high contrast support
+  border: var(--pf-t--global--border--width--high-contrast--regular) solid
+    var(--pf-t--global--border--color--high-contrast);
 
   &-dots {
     position: relative;


### PR DESCRIPTION
Add borders to container that show in high contrast mode.

<img width="304" height="88" alt="Screenshot 2025-10-20 at 5 08 59 PM" src="https://github.com/user-attachments/assets/d9cb4d39-f608-4007-b326-f61aaf3c01b1" />


https://chatbot-pr-chatbot-712.surge.sh/patternfly-ai/chatbot/messages (third one down)