### PR TITLE
chore(docs): Enable high contrast switcher

### DIFF
--- a/packages/module/patternfly-docs/patternfly-docs.config.js
+++ b/packages/module/patternfly-docs/patternfly-docs.config.js
@@ -4,5 +4,6 @@ module.exports = {
   topNavItems: [],
   hasThemeSwitcher: true,
   hasRTLSwitcher: true,
+  hasHighContrastSwitcher: true,
   port: 8006
 };


### PR DESCRIPTION
Will make dev/testing easier in extension docs. May require https://github.com/patternfly/chatbot/pull/724 first. We don't want to release this yet but may want to re-release for 724.