### PR TITLE
feat(ToolCall/DeepThinking/Tool Response): Add support for high contrast

### DIFF
--- a/packages/module/src/DeepThinking/DeepThinking.scss
+++ b/packages/module/src/DeepThinking/DeepThinking.scss
@@ -1,5 +1,5 @@
 .pf-chatbot__deep-thinking {
-  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--default);
   overflow: unset;
 }
 
@@ -21,10 +21,4 @@
 
 .pf-chatbot__deep-thinking-body {
   color: var(--pf-t--global--text--color--subtle);
-}
-
-:root:where(.pf-v6-theme-high-contrast) {
-  .pf-chatbot__deep-thinking {
-    --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--high-contrast);
-  }
 }

--- a/packages/module/src/ToolCall/ToolCall.scss
+++ b/packages/module/src/ToolCall/ToolCall.scss
@@ -1,6 +1,6 @@
 .pf-chatbot__tool-call {
   --pf-v6-c-card--BorderRadius: var(--pf-t--global--border--radius--small);
-  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--default);
 
   overflow: unset;
   row-gap: var(--pf-t--global--spacer--sm);
@@ -33,11 +33,5 @@
 
   .pf-chatbot__tool-call-action-list {
     justify-content: flex-end;
-  }
-}
-
-:root:where(.pf-v6-theme-high-contrast) {
-  .pf-chatbot__tool-call {
-    --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--high-contrast);
   }
 }

--- a/packages/module/src/ToolResponse/ToolResponse.scss
+++ b/packages/module/src/ToolResponse/ToolResponse.scss
@@ -1,5 +1,5 @@
 .pf-chatbot__tool-response {
-  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--default);
   overflow: unset;
 }
 
@@ -25,23 +25,12 @@
 }
 
 .pf-chatbot__tool-response-card {
-  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--control--read-only);
+  --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--default);
   --pf-v6-c-card--first-child--PaddingBlockStart: var(--pf-t--global--spacer--sm);
   --pf-v6-c-card__title--not--last-child--PaddingBlockEnd: var(--pf-t--global--spacer--sm);
   --pf-v6-c-card--c-divider--child--PaddingBlockStart: var(--pf-t--global--spacer--sm);
 
   .pf-v6-c-divider {
-    --pf-v6-c-divider--Color: var(--pf-t--global--border--color--control--read-only);
-  }
-}
-
-:root:where(.pf-v6-theme-high-contrast) {
-  .pf-chatbot__tool-response,
-  .pf-chatbot__tool-response-card {
-    --pf-v6-c-card--BorderColor: var(--pf-t--global--border--color--high-contrast);
-
-    .pf-v6-c-divider {
-      --pf-v6-c-divider--Color: var(--pf-t--global--border--color--high-contrast);
-    }
+    --pf-v6-c-divider--Color: var(--pf-t--global--border--color--default);
   }
 }


### PR DESCRIPTION
I couldn't figure out a good way to do this without looking for the class on root since these have different border styles than our usual cards, and the token wasn't inheriting the HCC borders. Let me know if there is in fact a better way.

Affected demos:
1. https://chatbot-pr-chatbot-728.surge.sh/patternfly-ai/chatbot/messages#messages-with-tool-calls
2. https://chatbot-pr-chatbot-728.surge.sh/patternfly-ai/chatbot/messages#messages-with-tool-responses
3. https://chatbot-pr-chatbot-728.surge.sh/patternfly-ai/chatbot/messages#messages-with-deep-thinking

<img width="898" height="470" alt="Screenshot 2025-10-21 at 2 55 20 PM" src="https://github.com/user-attachments/assets/40af0d04-288c-42ea-9012-8e30c2b609a7" />
<img width="887" height="353" alt="Screenshot 2025-10-21 at 2 55 04 PM" src="https://github.com/user-attachments/assets/2ef13f7a-ca08-4f36-9d1e-9dae1cf93258" />
<img width="892" height="489" alt="Screenshot 2025-10-21 at 2 55 09 PM" src="https://github.com/user-attachments/assets/2996367b-7346-43b2-ba4c-c4048bfca9c0" />
<img width="910" height="380" alt="Screenshot 2025-10-21 at 2 55 16 PM" src="https://github.com/user-attachments/assets/90c4028b-f502-4473-8f34-3bff91f4c4fa" />
