### PR TITLE
fix(ResponseActions): Adjust focus background color

### DIFF
--- a/packages/module/src/ResponseActions/ResponseActions.scss
+++ b/packages/module/src/ResponseActions/ResponseActions.scss
@@ -17,7 +17,7 @@
     }
     &:focus {
       --pf-v6-c-button__icon--Color: var(--pf-t--global--icon--color--regular);
-      background-color: var(--pf-v6-c-button--hover--BackgroundColor);
+      --pf-v6-c-button--BackgroundColor: var(--pf-v6-c-button--hover--BackgroundColor);
     }
   }
 }


### PR DESCRIPTION
Adjusted focus state color.

|Before|After|
|-|-|
|<img width="396" height="179" alt="Screenshot 2025-10-28 at 2 57 46 PM" src="https://github.com/user-attachments/assets/5f5fcf82-fef4-4691-8a44-d218e9a11bcd" />|<img width="309" height="188" alt="Screenshot 2025-10-28 at 2 57 05 PM" src="https://github.com/user-attachments/assets/65256f04-f67d-40d6-ad6d-1cc2a06990d9" />


Demo: https://chatbot-pr-chatbot-739.surge.sh/patternfly-ai/chatbot/messages#message-actions-clicked-state