### PR TITLE
chore(docs): Adjust live progress summary card demo

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessageWithExtraContent.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessageWithExtraContent.tsx
@@ -366,7 +366,9 @@ Setting up cluster console...`;
                       <FlexItem>{stage.name}</FlexItem>
                     </Flex>
                   </AccordionToggle>
-                  <AccordionContent id={stage.id.replace('-toggle', '')}>{renderCodeBlock(stage)}</AccordionContent>
+                  <AccordionContent id={stage.id.replace('-toggle', '')} style={{ border: '0px' }}>
+                    {renderCodeBlock(stage)}
+                  </AccordionContent>
                 </AccordionItem>
               ))}
             </Accordion>


### PR DESCRIPTION
Addition of high contrast styles created some weird borders - adjusting.

This technically works - I don't see a token I can plug into.

Demo: https://chatbot-pr-chatbot-741.surge.sh/patternfly-ai/chatbot/messages#custom-message-content (second one down - have to open expandable).

| Before | After |
|-|-|
|<img width="988" height="496" alt="Screenshot 2025-10-29 at 8 48 30 AM" src="https://github.com/user-attachments/assets/df519b57-c954-4fc1-a346-d82dd64a347c" />|<img width="1000" height="554" alt="Screenshot 2025-10-29 at 8 47 40 AM" src="https://github.com/user-attachments/assets/5f82985a-7929-4e0c-8892-e12cdb8c069b" />

This was originally based on a Mark Riggan design shopped around to senior management - we were asked to prove that it could be done with PatternFly, but we're inlining some things since he had a few weird styles.
