### PR TITLE
fix(CodeEditor): Don't use CDN for loading monaco

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,7 +38,8 @@ module.exports = {
     customReact: 'react',
     reactRedux: 'react-redux',
     PFReactCore: '@patternfly/react-core',
-    PFReactTable: '@patternfly/react-table'
+    PFReactTable: '@patternfly/react-table',
+    '^monaco-editor$': '<rootDir>/packages/module/src/__mocks__/monaco-editor.ts'
   },
   globalSetup: '<rootDir>/config/globalSetup.js',
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10140,6 +10140,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "dev": true,
@@ -18806,9 +18812,26 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.52.2",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "dompurify": "3.1.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/moniker": {
       "version": "0.1.2",
@@ -27019,6 +27042,7 @@
         "@patternfly/react-table": "^6.1.0",
         "@segment/analytics-next": "^1.76.0",
         "clsx": "^2.1.0",
+        "monaco-editor": "^0.54.0",
         "path-browserify": "^1.0.1",
         "posthog-js": "^1.194.4",
         "react-markdown": "^9.0.1",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -39,6 +39,7 @@
     "@patternfly/react-table": "^6.1.0",
     "@segment/analytics-next": "^1.76.0",
     "clsx": "^2.1.0",
+    "monaco-editor": "^0.54.0",
     "path-browserify": "^1.0.1",
     "posthog-js": "^1.194.4",
     "react-markdown": "^9.0.1",

--- a/packages/module/src/CodeModal/CodeModal.tsx
+++ b/packages/module/src/CodeModal/CodeModal.tsx
@@ -5,7 +5,8 @@
 import type { FunctionComponent, MouseEvent } from 'react';
 import { useState, useEffect, useRef } from 'react';
 import path from 'path-browserify';
-import type monaco from 'monaco-editor';
+import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
 
 // Import PatternFly components
 import { CodeEditor } from '@patternfly/react-code-editor';
@@ -21,6 +22,9 @@ import {
 import FileDetails, { extensionToLanguage } from '../FileDetails';
 import { ChatbotDisplayMode } from '../Chatbot';
 import ChatbotModal from '../ChatbotModal/ChatbotModal';
+
+// Configure Monaco loader to use the npm package instead of CDN
+loader.config({ monaco });
 
 export interface CodeModalProps {
   /** Class applied to code editor */

--- a/packages/module/src/__mocks__/monaco-editor.ts
+++ b/packages/module/src/__mocks__/monaco-editor.ts
@@ -1,0 +1,19 @@
+const mockEditor = {
+  layout: jest.fn(),
+  focus: jest.fn(),
+  dispose: jest.fn(),
+  getModel: jest.fn(),
+  updateOptions: jest.fn()
+};
+
+const mockModel = {
+  updateOptions: jest.fn(),
+  dispose: jest.fn()
+};
+
+module.exports = {
+  editor: {
+    create: jest.fn(() => mockEditor),
+    getModels: jest.fn(() => [mockModel])
+  }
+};


### PR DESCRIPTION
The @patternfly/react-code-editor library uses a CDN to load some Monaco stuff by default. This doesn't work for all consumers. Adjusting so we can do without the CDN.

Found this in the docs for [@patternfly/react-code-editor](https://www.npmjs.com/package/@patternfly/react-code-editor): 

> To use monaco-editor as an npm package and avoid using CDN
The @monaco-editor/react package is built on the monaco-editor package, which will fetch some additional files using CDN by default. To avoid this, include monaco-editor as a dependency and insert the following into your code:
>
> import * as monaco from 'monaco-editor';
> import { loader } from '@monaco-editor/react';
> 
> loader.config({ monaco });
> This may require the additonal webpack plugins such as monaco-editor-webpack-plugin. To properly install the library monaco-editor-webpack-plugin be sure to follow the [plugin instructions](https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin)

Doing this seems to get us off the CDN network calls, but I'm seeing some grumpy console warnings from Monaco:

> hook.js:608 Could not create web worker(s). Falling back to loading web worker code in main thread, which might cause UI freezes. Please see https://github.com/microsoft/monaco-editor#faq
overrideMethod @ hook.js:608
> hook.js:608 You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker

The editor does seem to work though? I don't see a webpack config we can plug into either.

You can see an example of Monaco usage here: https://chatbot-pr-chatbot-743.surge.sh/patternfly-ai/chatbot/messages/#editable-attachments