### PR TITLE
chore(docs): Add example of quick response with icons

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
 import patternflyAvatar from './patternfly_avatar.jpg';
+import { CopyIcon, WrenchIcon } from '@patternfly/react-icons';
 
 export const MessageWithQuickResponsesExample: FunctionComponent = () => (
   <>
@@ -73,6 +74,16 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
         { id: '2', content: 'No', onClick: () => alert('Clicked id 2') }
       ]}
       isCompact
+    />
+    <Message
+      name="Bot"
+      role="bot"
+      avatar={patternflyAvatar}
+      content="Example with icons"
+      quickResponses={[
+        { id: '1', content: 'Update your settings', onClick: () => alert('Clicked yes'), icon: <WrenchIcon /> },
+        { id: '2', content: 'Copy', onClick: () => alert('Clicked no'), icon: <CopyIcon /> }
+      ]}
     />
   </>
 );


### PR DESCRIPTION
Demo: https://chatbot-pr-chatbot-757.surge.sh/patternfly-ai/chatbot/messages#messages-with-quick-responses

<img width="424" height="145" alt="Screenshot 2025-11-11 at 9 46 44 AM" src="https://github.com/user-attachments/assets/250587d2-087b-4ad8-87b9-a13fd66247b4" />
