### PR TITLE
fix(CodeModal): Switch over to lazy loading Monaco

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3776,6 +3776,8 @@
     },
     "node_modules/@monaco-editor/react": {
       "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/loader": "^1.5.0"
@@ -10138,7 +10140,8 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -18780,6 +18783,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.1.7",
         "marked": "14.0.0"
@@ -18790,6 +18794,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26967,7 +26972,6 @@
         "@patternfly/react-table": "^6.1.0",
         "@segment/analytics-next": "^1.76.0",
         "clsx": "^2.1.0",
-        "monaco-editor": "^0.54.0",
         "path-browserify": "^1.0.1",
         "posthog-js": "^1.194.4",
         "react-markdown": "^9.0.1",
@@ -27004,8 +27008,18 @@
         "victory-voronoi-container": "^37.1.1"
       },
       "peerDependencies": {
+        "@monaco-editor/react": "^4.7.0",
+        "monaco-editor": "^0.54.0",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@monaco-editor/react": {
+          "optional": false
+        },
+        "monaco-editor": {
+          "optional": false
+        }
       }
     },
     "packages/module/node_modules/@patternfly/patternfly": {

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -36,11 +36,10 @@
     "@patternfly/react-code-editor": "^6.1.0",
     "@patternfly/react-core": "^6.1.0",
     "@patternfly/react-icons": "^6.1.0",
-    "@patternfly/react-table": "^6.1.0",
     "@patternfly/react-styles": "^6.1.0",
+    "@patternfly/react-table": "^6.1.0",
     "@segment/analytics-next": "^1.76.0",
     "clsx": "^2.1.0",
-    "monaco-editor": "^0.54.0",
     "path-browserify": "^1.0.1",
     "posthog-js": "^1.194.4",
     "react-markdown": "^9.0.1",
@@ -52,8 +51,18 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
+    "monaco-editor": "^0.54.0",
+    "@monaco-editor/react": "^4.7.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "monaco-editor": {
+      "optional": false
+    },
+    "@monaco-editor/react": {
+      "optional": false
+    }
   },
   "devDependencies": {
     "@octokit/rest": "^18.0.0",

--- a/packages/module/tsconfig.json
+++ b/packages/module/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
-    "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "es2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */


### PR DESCRIPTION
Red Hat Developer Hub needs a smaller bundle size. Checking with Karthik to see if lazy loading/peer dep changes work - Backstage doesn't have webpack plugin configuration and neither do we. Backstage uses Webpack under the hood in a non-accessible way, so it may pick this up and reduce the bundle size.

Am interested to know if they can also try using React.lazy/Suspense when loading the Code Modal - it may be that Backstage is able to optimize if that is done, but I am unsure.

Does add a loading state if the third-party dependency needs a moment.

Will also see if Joachim has ideas. 