### PR TITLE
feat(ResponseActions): added opt-in for hiding actions until interaction

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithResponseActions.tsx
@@ -4,22 +4,43 @@ import Message from '@patternfly/chatbot/dist/dynamic/Message';
 import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const ResponseActionExample: FunctionComponent = () => (
-  <Message
-    name="Bot"
-    role="bot"
-    avatar={patternflyAvatar}
-    content="I updated your account with those settings. You're ready to set up your first dashboard!"
-    actions={{
-      // eslint-disable-next-line no-console
-      positive: { onClick: () => console.log('Good response') },
-      // eslint-disable-next-line no-console
-      negative: { onClick: () => console.log('Bad response') },
-      // eslint-disable-next-line no-console
-      copy: { onClick: () => console.log('Copy') },
-      // eslint-disable-next-line no-console
-      download: { onClick: () => console.log('Download') },
-      // eslint-disable-next-line no-console
-      listen: { onClick: () => console.log('Listen') }
-    }}
-  />
+  <>
+    <Message
+      name="Bot"
+      role="bot"
+      avatar={patternflyAvatar}
+      content="I updated your account with those settings. You're ready to set up your first dashboard!"
+      actions={{
+        // eslint-disable-next-line no-console
+        positive: { onClick: () => console.log('Good response') },
+        // eslint-disable-next-line no-console
+        negative: { onClick: () => console.log('Bad response') },
+        // eslint-disable-next-line no-console
+        copy: { onClick: () => console.log('Copy') },
+        // eslint-disable-next-line no-console
+        download: { onClick: () => console.log('Download') },
+        // eslint-disable-next-line no-console
+        listen: { onClick: () => console.log('Listen') }
+      }}
+    />
+    <Message
+      name="Bot"
+      role="bot"
+      showActionsOnInteraction
+      avatar={patternflyAvatar}
+      content="This message has response actions visually hidden until you hover over the message via mouse, or an action would receive focus via keyboard."
+      actions={{
+        // eslint-disable-next-line no-console
+        positive: { onClick: () => console.log('Good response') },
+        // eslint-disable-next-line no-console
+        negative: { onClick: () => console.log('Bad response') },
+        // eslint-disable-next-line no-console
+        copy: { onClick: () => console.log('Copy') },
+        // eslint-disable-next-line no-console
+        download: { onClick: () => console.log('Download') },
+        // eslint-disable-next-line no-console
+        listen: { onClick: () => console.log('Listen') }
+      }}
+    />
+  </>
 );

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/Messages.md
@@ -95,14 +95,16 @@ For example, you can use the default divider to display a "timestamp" for more s
 
 ### Message actions
 
-You can add actions to a message, to allow users to interact with the message content. These actions can include:
+To let users interact with a bot's responses, you can add support for message actions. While you can customize message actions to your needs, default options include the following:
 
-- Feedback responses that allow users to rate a message as "good" or "bad".
-- Copy and share controls that allow users to share the message content with others.
-- An edit action to allow users to edit a message they previously sent. This should only be applied to user messages - see the [user messages example](#user-messages) for details on how to implement this action.
-- A listen action, that will read the message content out loud.
+- Positive and negative feedback: Allows users to rate a message as "good" or "bad."
+- Copy: Allows users to copy the message content to their clipboard.
+- Download: Allows users to download the message content.
+- Listen: Reads the message content out loud using text-to-speech.
 
-**Note:** The logic for the actions is not built into the component and must be implemented by the consuming application.
+You can display message actions by default, or use the `showActionsOnInteraction` prop to reveal actions on hover or keyboard focus.
+
+**Note**: The underlying logic for these actions is not built-in and must be implemented within the consuming application.
 
 ```js file="./MessageWithResponseActions.tsx"
 
@@ -140,10 +142,9 @@ When `persistActionSelection` is `true`:
 
 ### Message actions that fill
 
-To provide enhanced visual feedback when users interact with response actions, you can enable icon swapping by setting `useFilledIconsOnClick` to `true`. When enabled, the predefined "positive" and "negative" actions will automatically swap to their filled icon counterparts when clicked, replacing the original outlined icon variants. 
+To provide enhanced visual feedback when users interact with response actions, you can enable icon swapping by setting `useFilledIconsOnClick` to `true`. When enabled, the predefined "positive" and "negative" actions will automatically swap to their filled icon counterparts when clicked, replacing the original outlined icon variants.
 
 This is especially useful for actions that are intended to persist (such as the "positive" and "negative" responses), so that a user's selection is more clear and emphasized.
-
 
 ```js file="./MessageWithIconSwapping.tsx"
 

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -92,6 +92,15 @@
     gap: var(--pf-t--global--spacer--sm);
   }
 
+  .pf-m-visible-interaction {
+    opacity: 0;
+  }
+
+  &:hover .pf-m-visible-interaction,
+  .pf-m-visible-interaction:focus-within {
+    opacity: 1;
+  }
+
   // targets footnotes specifically
   .footnotes,
   .pf-chatbot__message-text.footnotes {

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -94,6 +94,9 @@
 
   .pf-m-visible-interaction {
     opacity: 0;
+    transition-timing-function: var(--pf-t--global--motion--timing-function--default);
+    transition-duration: var(--pf-t--global--motion--duration--fade--short);
+    transition-property: opacity;
   }
 
   &:hover .pf-m-visible-interaction,

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -1415,4 +1415,140 @@ describe('Message', () => {
     expect(screen.getByText('ThumbsUpIcon')).toBeInTheDocument();
     expect(screen.queryByText('OutlinedThumbsUpIcon')).not.toBeInTheDocument();
   });
+
+  it('should apply pf-m-visible-interaction class to response actions when showActionsOnInteraction is true', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        showActionsOnInteraction
+        actions={{
+          positive: { onClick: jest.fn() }
+        }}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions');
+    expect(responseContainer).toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class to response actions when showActionsOnInteraction is false', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        showActionsOnInteraction={false}
+        actions={{
+          positive: { onClick: jest.fn() }
+        }}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions');
+    expect(responseContainer).not.toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class to response actions by default', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        actions={{
+          positive: { onClick: jest.fn() }
+        }}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions');
+    expect(responseContainer).not.toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should apply pf-m-visible-interaction class to grouped actions container when showActionsOnInteraction is true', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        showActionsOnInteraction
+        actions={[
+          {
+            positive: { onClick: jest.fn() },
+            negative: { onClick: jest.fn() }
+          },
+          {
+            copy: { onClick: jest.fn() }
+          }
+        ]}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions-groups');
+    expect(responseContainer).toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class to grouped actions container when showActionsOnInteraction is false', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        showActionsOnInteraction={false}
+        actions={[
+          {
+            positive: { onClick: jest.fn() },
+            negative: { onClick: jest.fn() }
+          },
+          {
+            copy: { onClick: jest.fn() }
+          }
+        ]}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions-groups');
+    expect(responseContainer).not.toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class to grouped actions container by default', () => {
+    render(
+      <Message
+        avatar="./img"
+        role="bot"
+        name="Bot"
+        content="Hi"
+        actions={[
+          {
+            positive: { onClick: jest.fn() },
+            negative: { onClick: jest.fn() }
+          },
+          {
+            copy: { onClick: jest.fn() }
+          }
+        ]}
+      />
+    );
+
+    const responseContainer = screen
+      .getByRole('button', { name: 'Good response' })
+      .closest('.pf-chatbot__response-actions-groups');
+    expect(responseContainer).not.toHaveClass('pf-m-visible-interaction');
+  });
 });

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -114,6 +114,10 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
    * For finer control of multiple action groups, use persistActionSelection on each group.
    */
   persistActionSelection?: boolean;
+  /** Flag indicating whether the actions container is only visible when a message is hovered or an action would receive focus. Note
+   * that setting this to true will append tooltips inline instead of the document.body.
+   */
+  showActionsOnInteraction?: boolean;
   /** Sources for message */
   sources?: SourcesCardProps;
   /** Label for the English word "AI," used to tag messages with role "bot" */
@@ -214,6 +218,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
   isLoading,
   actions,
   persistActionSelection,
+  showActionsOnInteraction = false,
   sources,
   botWord = 'AI',
   loadingWord = 'Loading message',
@@ -382,7 +387,12 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
                 {!isLoading && !isEditable && actions && (
                   <>
                     {Array.isArray(actions) ? (
-                      <div className="pf-chatbot__response-actions-groups">
+                      <div
+                        className={css(
+                          'pf-chatbot__response-actions-groups',
+                          showActionsOnInteraction && 'pf-m-visible-interaction'
+                        )}
+                      >
                         {actions.map((actionGroup, index) => (
                           <ResponseActions
                             key={index}
@@ -397,6 +407,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
                         actions={actions}
                         persistActionSelection={persistActionSelection}
                         useFilledIconsOnClick={useFilledIconsOnClick}
+                        showActionsOnInteraction={showActionsOnInteraction}
                       />
                     )}
                   </>

--- a/packages/module/src/ResponseActions/ResponseActions.test.tsx
+++ b/packages/module/src/ResponseActions/ResponseActions.test.tsx
@@ -437,6 +437,65 @@ describe('ResponseActions', () => {
     expect(customBtn).not.toHaveClass('pf-chatbot__button--response-action-clicked');
   });
 
+  it('should apply pf-m-visible-interaction class when showActionsOnInteraction is true', () => {
+    render(
+      <ResponseActions
+        data-testid="test-id"
+        actions={{
+          positive: { onClick: jest.fn() },
+          negative: { onClick: jest.fn() }
+        }}
+        showActionsOnInteraction
+      />
+    );
+
+    expect(screen.getByTestId('test-id')).toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class when showActionsOnInteraction is false', () => {
+    render(
+      <ResponseActions
+        data-testid="test-id"
+        actions={{
+          positive: { onClick: jest.fn() },
+          negative: { onClick: jest.fn() }
+        }}
+        showActionsOnInteraction={false}
+      />
+    );
+
+    expect(screen.getByTestId('test-id')).not.toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should not apply pf-m-visible-interaction class by default', () => {
+    render(
+      <ResponseActions
+        data-testid="test-id"
+        actions={{
+          positive: { onClick: jest.fn() },
+          negative: { onClick: jest.fn() }
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('test-id')).not.toHaveClass('pf-m-visible-interaction');
+  });
+
+  it('should render with custom className', () => {
+    render(
+      <ResponseActions
+        data-testid="test-id"
+        actions={{
+          positive: { onClick: jest.fn() },
+          negative: { onClick: jest.fn() }
+        }}
+        className="custom-class"
+      />
+    );
+
+    expect(screen.getByTestId('test-id')).toHaveClass('custom-class');
+  });
+
   describe('icon swapping with useFilledIconsOnClick', () => {
     it('should render outline icons by default', () => {
       render(

--- a/packages/module/src/ResponseActions/ResponseActions.tsx
+++ b/packages/module/src/ResponseActions/ResponseActions.tsx
@@ -186,9 +186,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
   // We want to append the tooltip inline so that hovering the tooltip keeps the actions container visible
   // when showActionsOnInteraction is true. Otherwise hovering the tooltip causes the actions container
   // to disappear but the tooltip will remain visible.
-  const getTooltipContainer = (): HTMLElement => {
-    return responseActions.current || document.body;
-  };
+  const getTooltipContainer = (): HTMLElement => responseActions.current || document.body;
 
   const getTooltipProps = (tooltipProps?: TooltipProps) =>
     ({

--- a/packages/module/src/ResponseActions/ResponseActions.tsx
+++ b/packages/module/src/ResponseActions/ResponseActions.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-icons';
 import ResponseActionButton from './ResponseActionButton';
 import { ButtonProps, TooltipProps } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 
 export interface ActionProps extends Omit<ButtonProps, 'ref'> {
   /** Aria-label for the button */
@@ -51,6 +52,8 @@ type ExtendedActionProps = ActionProps & {
  */
 
 export interface ResponseActionProps {
+  /** Additional classes for the response actions container. */
+  className?: string;
   /** Props for message actions, such as feedback (positive or negative), copy button, share, and listen */
   actions: Record<string, ExtendedActionProps | undefined> & {
     positive?: ActionProps;
@@ -67,12 +70,19 @@ export interface ResponseActionProps {
   /** When true, automatically swaps to filled icon variants when predefined actions are clicked.
    * Predefined actions will use filled variants (e.g., ThumbsUpIcon) when clicked and outline variants (e.g., OutlinedThumbsUpIcon) when not clicked. */
   useFilledIconsOnClick?: boolean;
+  /** Flag indicating whether the actions container is only visible when a message is hovered or an action would receive focus. Note
+   * that setting this to true will append tooltips inline instead of the document.body.
+   */
+  showActionsOnInteraction?: boolean;
 }
 
 export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
+  className,
   actions,
   persistActionSelection = false,
-  useFilledIconsOnClick = false
+  useFilledIconsOnClick = false,
+  showActionsOnInteraction = false,
+  ...props
 }) => {
   const [activeButton, setActiveButton] = useState<string>();
   const [clickStatePersisted, setClickStatePersisted] = useState<boolean>(false);
@@ -173,8 +183,25 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
     return iconMap[actionName].outlined;
   };
 
+  // We want to append the tooltip inline so that hovering the tooltip keeps the actions container visible
+  // when showActionsOnInteraction is true. Otherwise hovering the tooltip causes the actions container
+  // to disappear but the tooltip will remain visible.
+  const getTooltipContainer = (): HTMLElement => {
+    return responseActions.current || document.body;
+  };
+
+  const getTooltipProps = (tooltipProps?: TooltipProps) =>
+    ({
+      ...(showActionsOnInteraction && { appendTo: getTooltipContainer }),
+      ...tooltipProps
+    }) as TooltipProps;
+
   return (
-    <div ref={responseActions} className="pf-chatbot__response-actions">
+    <div
+      ref={responseActions}
+      className={css('pf-chatbot__response-actions', showActionsOnInteraction && 'pf-m-visible-interaction', className)}
+      {...props}
+    >
       {positive && (
         <ResponseActionButton
           {...positive}
@@ -185,7 +212,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={positive.isDisabled}
           tooltipContent={positive.tooltipContent ?? 'Good response'}
           clickedTooltipContent={positive.clickedTooltipContent ?? 'Good response recorded'}
-          tooltipProps={positive.tooltipProps}
+          tooltipProps={getTooltipProps(positive.tooltipProps)}
           icon={getIcon('positive')}
           isClicked={activeButton === 'positive'}
           ref={positive.ref}
@@ -203,7 +230,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={negative.isDisabled}
           tooltipContent={negative.tooltipContent ?? 'Bad response'}
           clickedTooltipContent={negative.clickedTooltipContent ?? 'Bad response recorded'}
-          tooltipProps={negative.tooltipProps}
+          tooltipProps={getTooltipProps(negative.tooltipProps)}
           icon={getIcon('negative')}
           isClicked={activeButton === 'negative'}
           ref={negative.ref}
@@ -221,7 +248,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={copy.isDisabled}
           tooltipContent={copy.tooltipContent ?? 'Copy'}
           clickedTooltipContent={copy.clickedTooltipContent ?? 'Copied'}
-          tooltipProps={copy.tooltipProps}
+          tooltipProps={getTooltipProps(copy.tooltipProps)}
           icon={<OutlinedCopyIcon />}
           isClicked={activeButton === 'copy'}
           ref={copy.ref}
@@ -239,7 +266,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={edit.isDisabled}
           tooltipContent={edit.tooltipContent ?? 'Edit '}
           clickedTooltipContent={edit.clickedTooltipContent ?? 'Editing'}
-          tooltipProps={edit.tooltipProps}
+          tooltipProps={getTooltipProps(edit.tooltipProps)}
           icon={<PencilAltIcon />}
           isClicked={activeButton === 'edit'}
           ref={edit.ref}
@@ -257,7 +284,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={share.isDisabled}
           tooltipContent={share.tooltipContent ?? 'Share'}
           clickedTooltipContent={share.clickedTooltipContent ?? 'Shared'}
-          tooltipProps={share.tooltipProps}
+          tooltipProps={getTooltipProps(share.tooltipProps)}
           icon={<ExternalLinkAltIcon />}
           isClicked={activeButton === 'share'}
           ref={share.ref}
@@ -275,7 +302,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={download.isDisabled}
           tooltipContent={download.tooltipContent ?? 'Download'}
           clickedTooltipContent={download.clickedTooltipContent ?? 'Downloaded'}
-          tooltipProps={download.tooltipProps}
+          tooltipProps={getTooltipProps(download.tooltipProps)}
           icon={<DownloadIcon />}
           isClicked={activeButton === 'download'}
           ref={download.ref}
@@ -293,7 +320,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           isDisabled={listen.isDisabled}
           tooltipContent={listen.tooltipContent ?? 'Listen'}
           clickedTooltipContent={listen.clickedTooltipContent ?? 'Listening'}
-          tooltipProps={listen.tooltipProps}
+          tooltipProps={getTooltipProps(listen.tooltipProps)}
           icon={<VolumeUpIcon />}
           isClicked={activeButton === 'listen'}
           ref={listen.ref}
@@ -312,7 +339,7 @@ export const ResponseActions: FunctionComponent<ResponseActionProps> = ({
           className={additionalActions[action]?.className}
           isDisabled={additionalActions[action]?.isDisabled}
           tooltipContent={additionalActions[action]?.tooltipContent}
-          tooltipProps={additionalActions[action]?.tooltipProps}
+          tooltipProps={getTooltipProps(additionalActions[action]?.tooltipProps)}
           clickedTooltipContent={additionalActions[action]?.clickedTooltipContent}
           icon={additionalActions[action]?.icon}
           isClicked={activeButton === action}


### PR DESCRIPTION
closes #792 

Updated the [message actions example](https://chatbot-pr-chatbot-806.surge.sh/extensions/chatbot/messages#message-actions) to include a Message that has this feature