### PR TITLE
feat(Message): add default bot message avatar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@octokit/rest": "^18.0.0",
-        "@patternfly/documentation-framework": "^6.44.0",
-        "@patternfly/patternfly": "^6.5.2",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-table": "^6.5.1",
+        "@patternfly/documentation-framework": "^6.47.0",
+        "@patternfly/patternfly": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-table": "^6.6.0",
         "@swc/core": "1.3.96",
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.4.2",
@@ -4426,9 +4426,9 @@
       "link": true
     },
     "node_modules/@patternfly/documentation-framework": {
-      "version": "6.44.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.44.3.tgz",
-      "integrity": "sha512-XFfKPu4I85nLP1X0vCV2ljjc6KWEWgFxt1tbnxtAxItapDqDN87LoYraDaJjipRhqngNF6X7J9H8GovjLOarhg==",
+      "version": "6.47.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/documentation-framework/-/documentation-framework-6.47.0.tgz",
+      "integrity": "sha512-IO2cBZtohrQCElX4UugBAS0ChdxuaGDSeQPWPtN0AUIus0V+n+CO6aIDQRL1cGjqJI7A4E9LPvhA92+ndOkDMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4495,11 +4495,11 @@
         "pf-docs-framework": "scripts/cli/cli.js"
       },
       "peerDependencies": {
-        "@patternfly/patternfly": "^6.5.2",
-        "@patternfly/react-code-editor": "^6.5.1",
-        "@patternfly/react-core": "^6.5.1",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-table": "^6.5.1",
+        "@patternfly/patternfly": "^6.6.0",
+        "@patternfly/react-code-editor": "^6.6.0",
+        "@patternfly/react-core": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-table": "^6.6.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
@@ -4714,9 +4714,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.5.2.tgz",
-      "integrity": "sha512-yZ71+1gt1VGzUN5amjDNd9NvttTnSOm9M0JeBL0YX1KaWXW1bmDPzTWEM+vQXuC4LVK0msHmR5hKB7KVpamAkA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.6.0.tgz",
+      "integrity": "sha512-drZ4wYFQdhYY+VxLIl8PqbYnJoEa0UrNhiUkMCKkgMVNPxmCfNa1d2eEA97tnp2aYew15jQp+MaZcQIQIG8wVg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4761,15 +4761,15 @@
       }
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.5.1.tgz",
-      "integrity": "sha512-Epd4iAX7/Uzo+Vl+6gX6f1BjhoX06DVV7pnZnQK4N4uknyXbfIGkmOJcE0Eq06z1cxiITV/h/JHI6WqzbOSaGA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.6.0.tgz",
+      "integrity": "sha512-WzR2tRI/KeAz2XZNgR2FmO8E06+n652bga0Bt/vDoNuWK3nTTCyO+1KYKRH06huGk3aIEjXDcBGCJQNt7LUJkA==",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
-        "@patternfly/react-core": "^6.5.1",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-styles": "^6.5.1",
+        "@patternfly/react-core": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
         "react-dropzone": "14.3.5",
         "tslib": "^2.8.1"
       },
@@ -4796,14 +4796,14 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.5.1.tgz",
-      "integrity": "sha512-fFZ0hcIyHJO27hxbf53W3m2R11l0O9WxR7CusJXuCEaNMP31ULrhf5Pv6ROdTrrs39Kl/yPv+2QuxQfe/4e72g==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.6.0.tgz",
+      "integrity": "sha512-MLYPcJvdDWHZqWcvEH2QhKtCg6APRfrDJ4o192/wc2LUaf4ViGVsVLKDMbaKCamhbGauv7KpffNCSy3fjRy4Bw==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-styles": "^6.5.1",
-        "@patternfly/react-tokens": "^6.5.1",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-tokens": "^6.6.0",
         "focus-trap": "7.6.6",
         "react-dropzone": "^14.3.5",
         "tslib": "^2.8.1"
@@ -4814,31 +4814,34 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.5.1.tgz",
-      "integrity": "sha512-CnuPvTTs4MMWx8CAUkmnY690ouN1bbHjunsyXu3QxvGOmzbztP+wS4BdiLS8TIXOIH80Yb7KPhnF8VkA+CduOA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.6.0.tgz",
+      "integrity": "sha512-cDDUm4PFxqeBo4PS08xO1eFd6CMTOppn5RS4fs2hAgu/vRFkPXuL0zZCkxgRg5asd/W4olEN7WrIAbvjKbHKiQ==",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.5.1.tgz",
-      "integrity": "sha512-yQMzUbbf6qYM/v3JbPvaCJTgxRbOKoEw229XZmnnM8gDvp8ECiI7LqihrAOK/NA6T6M3DDgsRMd2JurUBhPDEw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.6.0.tgz",
+      "integrity": "sha512-u/HzJ48Cg6Nb12dIVbj4g31lMDVHPHVKRXkRuPBcuK6MQyAsxSfcyWVivW7Lga8TsNhFW26JWB5ay+IW5xpZ8A==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.5.1.tgz",
-      "integrity": "sha512-JpX66ctLsg5snRRheDhuF2fHvXDG4UDKYfP5403kCAQ4Dz2dPu3PhlHi4AJol+egEBD2HfS/U37j7noQ1Y7mpA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.6.0.tgz",
+      "integrity": "sha512-aOVSAbtXagey1xRI8oIkK3I/csh6S00p42qqOkh6G1s5vMZM7oVQH/Nvvq8gIwx4lZ3f1m7IkdD7My8nml0Bsw==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.5.1",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-styles": "^6.5.1",
-        "@patternfly/react-tokens": "^6.5.1",
+        "@patternfly/react-core": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-tokens": "^6.6.0",
         "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
@@ -4848,9 +4851,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.5.1.tgz",
-      "integrity": "sha512-zwepLsIQTL0Lf4R2/PIBOk1m+pm0hYVT3lktf2H4+Y87eRIifwMRb19c+pr4hj4ckGvHs+WxwjTfTj2Qqwn5rw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.6.0.tgz",
+      "integrity": "sha512-oRUFYJAM9LKYTM9YRnd7rz3wB6ZoaBWit/Eu+EK22J4o5AhZRjLt0+ewXQ7I99dBP4c8BbnPEUFnxQYAroqNLg==",
       "license": "MIT"
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -24961,9 +24964,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -28117,11 +28120,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-code-editor": "^6.5.1",
-        "@patternfly/react-core": "^6.5.1",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-styles": "^6.5.1",
-        "@patternfly/react-table": "^6.5.1",
+        "@patternfly/react-code-editor": "^6.6.0",
+        "@patternfly/react-core": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-table": "^6.6.0",
         "@segment/analytics-next": "^1.76.0",
         "clsx": "^2.1.0",
         "path-browserify": "^1.0.1",
@@ -28136,8 +28139,8 @@
       },
       "devDependencies": {
         "@octokit/rest": "^18.0.0",
-        "@patternfly/documentation-framework": "^6.44.0",
-        "@patternfly/patternfly": "^6.5.2",
+        "@patternfly/documentation-framework": "^6.47.0",
+        "@patternfly/patternfly": "^6.6.0",
         "@patternfly/patternfly-a11y": "^5.0.0",
         "@types/dom-speech-recognition": "^0.0.4",
         "@types/react": "^18.2.61",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@octokit/rest": "^18.0.0",
-    "@patternfly/documentation-framework": "^6.44.0",
-    "@patternfly/patternfly": "^6.5.2",
-    "@patternfly/react-icons": "^6.5.1",
-    "@patternfly/react-table": "^6.5.1",
+    "@patternfly/documentation-framework": "^6.47.0",
+    "@patternfly/patternfly": "^6.6.0",
+    "@patternfly/react-icons": "^6.6.0",
+    "@patternfly/react-table": "^6.6.0",
     "@swc/core": "1.3.96",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
@@ -92,6 +92,5 @@
   },
   "dependencies": {
     "react-dropzone": "^14.3.8"
-  },
-  "packageManager": "yarn@4.5.0+sha512.837566d24eec14ec0f5f1411adb544e892b3454255e61fdef8fd05f3429480102806bac7446bc9daff3896b01ae4b62d00096c7e989f1596f2af10b927532f39"
+  }
 }

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -33,11 +33,11 @@
     "tag": "prerelease"
   },
   "dependencies": {
-    "@patternfly/react-code-editor": "^6.5.1",
-    "@patternfly/react-core": "^6.5.1",
-    "@patternfly/react-icons": "^6.5.1",
-    "@patternfly/react-styles": "^6.5.1",
-    "@patternfly/react-table": "^6.5.1",
+    "@patternfly/react-code-editor": "^6.6.0",
+    "@patternfly/react-core": "^6.6.0",
+    "@patternfly/react-icons": "^6.6.0",
+    "@patternfly/react-styles": "^6.6.0",
+    "@patternfly/react-table": "^6.6.0",
     "@segment/analytics-next": "^1.76.0",
     "clsx": "^2.1.0",
     "path-browserify": "^1.0.1",
@@ -66,8 +66,8 @@
   },
   "devDependencies": {
     "@octokit/rest": "^18.0.0",
-    "@patternfly/documentation-framework": "^6.44.0",
-    "@patternfly/patternfly": "^6.5.2",
+    "@patternfly/documentation-framework": "^6.47.0",
+    "@patternfly/patternfly": "^6.6.0",
     "@patternfly/patternfly-a11y": "^5.0.0",
     "@types/dom-speech-recognition": "^0.0.4",
     "@types/react": "^18.2.61",

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/BotMessage.tsx
@@ -8,7 +8,6 @@ import {
   Ref
 } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import squareImg from './PF-social-color-square.svg';
 import {
   AlertActionLink,
@@ -290,25 +289,18 @@ _Italic text, formatted with single underscores_
 
   return (
     <>
+      <Message name="Bot" role="bot" content={`This is a text-based message from a bot named "Bot."`} />
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
-        content={`This is a text-based message from a bot named "Bot."`}
-      />
-      <Message
-        name="Bot"
-        role="bot"
-        avatar={patternflyAvatar}
         content={`This is a text-based message from "Bot," with an updated timestamp.`}
         timestamp="1 hour ago"
       />
-      <Message name="Bot" role="bot" avatar={patternflyAvatar} content="Example content" isLoading />
-      <Message role="bot" avatar={patternflyAvatar} content="This message is from a nameless bot." />
+      <Message name="Bot" role="bot" content="Example content" isLoading />
+      <Message role="bot" content="This message is from a nameless bot." />
       <Message
         name="Default Openshift Container Platform Assistant That Can Help With Any Query You Might Need Help With"
         role="bot"
-        avatar={patternflyAvatar}
         content="This is a message from a bot with really long name: it's truncated!"
       />
       <Message
@@ -322,7 +314,6 @@ _Italic text, formatted with single underscores_
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         isMetadataVisible={false}
         content="This is a message from a bot with metadata not visible."
       />
@@ -355,7 +346,6 @@ _Italic text, formatted with single underscores_
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content={renderContent()}
         tableProps={
           variant === 'Table' ? { 'aria-label': 'App information and user roles for bot messages' } : undefined

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithClickedResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithClickedResponseActions.tsx
@@ -1,13 +1,11 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const ResponseActionClickedExample: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="I updated your account with those settings. You're ready to set up your first dashboard!"
     actions={{
       // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithCustomResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithCustomResponseActions.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
 
@@ -9,7 +8,6 @@ export const CustomActionExample: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="I updated your account with those settings. You're ready to set up your first dashboard!"
     actions={{
       regenerate: {

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithCustomStructure.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithCustomStructure.tsx
@@ -11,7 +11,6 @@ import ToolCall from '@patternfly/chatbot/dist/dynamic/ToolCall';
 import ToolResponse from '@patternfly/chatbot/dist/dynamic/ToolResponse';
 import FileDetailsLabel from '@patternfly/chatbot/dist/dynamic/FileDetailsLabel';
 import ResponseActions, { ResponseActionsGroups } from '@patternfly/chatbot/dist/dynamic/ResponseActions';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import userAvatar from './user_avatar.svg';
 
 const handlePositiveResponse = () => {
@@ -36,7 +35,7 @@ const handleListen = () => {
 
 export const MessageWithCustomStructure: FunctionComponent = () => (
   <>
-    <Message name="Bot" role="bot" avatar={patternflyAvatar}>
+    <Message name="Bot" role="bot">
       <MessageAndActions>
         <MarkdownContent
           content={`This is a basic message with a more custom, fine-tuned structure. You can pass markdown to the MarkdownContent component, such as **bold content with double asterisks** or _italic content with single underscores_.`}

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithDeepThinking.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithDeepThinking.tsx
@@ -1,13 +1,11 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const MessageWithDeepThinkingExample: FunctionComponent = () => (
   <>
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This example has a body description that's within the recommended limit of 2 lines."
       deepThinking={{
         toggleContent: 'Show thinking',
@@ -18,7 +16,6 @@ export const MessageWithDeepThinkingExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This example has deep thinking that is collapsed by default:"
       deepThinking={{
         isDefaultExpanded: false,
@@ -30,7 +27,6 @@ export const MessageWithDeepThinkingExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This example has deep thinking that is loading:"
       deepThinking={{
         isDefaultExpanded: false,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithDividers.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithDividers.tsx
@@ -1,21 +1,14 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import MessageDivider from '@patternfly/chatbot/dist/dynamic/MessageDivider';
 
 export const MessageWithDividersExample: FunctionComponent = () => (
   <>
-    <Message
-      name="Bot"
-      role="bot"
-      avatar={patternflyAvatar}
-      content={`This is a text-based message from a bot named "Bot."`}
-    />
+    <Message name="Bot" role="bot" content={`This is a text-based message from a bot named "Bot."`} />
     <MessageDivider variant="inset" content="1 hour ago" />
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content={`This is a text-based message from "Bot," with an updated timestamp.`}
       timestamp="1 hour ago"
     />

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithFeedback.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithFeedback.tsx
@@ -1,6 +1,5 @@
 import { useState, FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { Checkbox, FormGroup, Flex, FlexItem } from '@patternfly/react-core';
 
 export const MessageWithFeedbackExample: FunctionComponent = () => {
@@ -50,7 +49,6 @@ export const MessageWithFeedbackExample: FunctionComponent = () => {
           <Message
             name="Bot"
             role="bot"
-            avatar={patternflyAvatar}
             content="This is a message with the feedback card:"
             userFeedbackForm={{
               quickResponses: [
@@ -73,7 +71,6 @@ export const MessageWithFeedbackExample: FunctionComponent = () => {
           <Message
             name="Bot"
             role="bot"
-            avatar={patternflyAvatar}
             content="This is a compact message with the feedback card:"
             userFeedbackForm={{
               quickResponses: [
@@ -112,7 +109,6 @@ export const MessageWithFeedbackExample: FunctionComponent = () => {
           <Message
             name="Bot"
             role="bot"
-            avatar={patternflyAvatar}
             content="This is a thank-you message, which is displayed once the feedback card is submitted:"
             // eslint-disable-next-line no-console
             userFeedbackComplete={{
@@ -126,7 +122,6 @@ export const MessageWithFeedbackExample: FunctionComponent = () => {
           <Message
             name="Bot"
             role="bot"
-            avatar={patternflyAvatar}
             content="This is a compact thank-you message, which is displayed once the feedback card is submitted:"
             // eslint-disable-next-line no-console
             userFeedbackComplete={{

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithFeedbackTimeout.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithFeedbackTimeout.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useState } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { Button } from '@patternfly/react-core';
 
 export const MessageWithFeedbackTimeoutExample: FunctionComponent = () => {
@@ -17,7 +16,6 @@ export const MessageWithFeedbackTimeoutExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This completion message times out after you click **Show card**:"
         userFeedbackComplete={hasFeedback ? { timeout: true, onTimeout: () => setHasFeedback(false) } : undefined}
         isLiveRegion

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithIconSwapping.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithIconSwapping.tsx
@@ -1,13 +1,11 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const IconSwappingExample: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="Click the response actions to see the outlined icons swapped with the filled variants!"
     actions={{
       // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownDeepThinking.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownDeepThinking.tsx
@@ -1,12 +1,10 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const MessageWithMarkdownDeepThinkingExample: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="This example shows how to use Markdown formatting in deep thinking content. Note the use of shouldRetainStyles to maintain proper formatting:"
     deepThinking={{
       shouldRetainStyles: true,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownToolCall.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownToolCall.tsx
@@ -1,12 +1,10 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const MessageWithMarkdownToolCallExample: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="This example shows how to use Markdown formatting in tool call content. Note the use of shouldRetainStyles to maintain proper formatting:"
     toolCall={{
       shouldRetainStyles: true,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMarkdownToolResponse.tsx
@@ -1,6 +1,5 @@
 import { useState, FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { CopyIcon, WrenchIcon } from '@patternfly/react-icons';
 import {
   Button,
@@ -35,7 +34,6 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This example shows how to use Markdown formatting in tool response content. Note the use of shouldRetainStyles to maintain proper formatting:"
       toolResponse={{
         shouldRetainStyles: true,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMultipleActionGroups.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithMultipleActionGroups.tsx
@@ -1,14 +1,12 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const MessageWithMultipleActionGroups: FunctionComponent = () => (
   <>
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This message contains multiple action groups, each with their own selection persistence: \n1. Feedback actions (thumbs up/down) with persistent selections \n2. Utility actions (copy, download) with non-persistent selections \n3. Listen action with persistent selection"
       actions={[
         {
@@ -41,7 +39,6 @@ export const MessageWithMultipleActionGroups: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This message contains multiple action groups, both of which persist selections."
       actions={[
         {

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithPersistedActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithPersistedActions.tsx
@@ -1,13 +1,11 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const MessageWithPersistedActions: FunctionComponent = () => (
   <Message
     name="Bot"
     role="bot"
-    avatar={patternflyAvatar}
     content="I updated your account with those settings. You're ready to set up your first dashboard! Click a button and then click outside the message - notice the selection persists."
     actions={{
       // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickResponses.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { CopyIcon, WrenchIcon } from '@patternfly/react-icons';
 
 export const MessageWithQuickResponsesExample: FunctionComponent = () => (
@@ -8,7 +7,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Did you clear your cache?"
       quickResponses={[
         { id: '1', content: 'Yes', onClick: () => alert('Clicked yes') },
@@ -18,7 +16,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="What browser are you noticing the issue in?"
       quickResponses={[
         { id: '1', content: 'Microsoft Edge', onClick: () => alert('Clicked Edge') },
@@ -31,7 +28,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Welcome back, User! How can I help you today?"
       quickResponses={[
         { id: '1', content: 'Help me with an access issue', onClick: () => alert('Clicked id 1') },
@@ -44,7 +40,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Did you clear your cache?"
       quickResponses={[
         { id: '1', content: 'Yes', isDisabled: true },
@@ -54,7 +49,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Welcome back, User! How can I help you today?"
       quickResponses={[
         { id: '1', content: 'Help me with an access issue', onClick: () => alert('Clicked id 1') },
@@ -67,7 +61,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Example with compact responses"
       quickResponses={[
         { id: '1', content: 'Yes', onClick: () => alert('Clicked id 1') },
@@ -78,7 +71,6 @@ export const MessageWithQuickResponsesExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Example with icons"
       quickResponses={[
         { id: '1', content: 'Update your settings', onClick: () => alert('Clicked yes'), icon: <WrenchIcon /> },

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickStart.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithQuickStart.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { explorePipelinesQuickStart } from './explore-pipeline-quickstart.ts';
 import { monitorSampleAppQuickStart } from '@patternfly/chatbot/src/Message/QuickStarts/monitor-sampleapp-quickstart.ts';
 import { QuickStart } from '@patternfly/chatbot/dist/esm/Message/QuickStarts/types';
@@ -10,7 +9,6 @@ export const MessageWithQuickStartExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Follow this quick guide to install the Pipelines Operator."
       quickStarts={{
         quickStart: explorePipelinesQuickStart as QuickStart,
@@ -20,7 +18,6 @@ export const MessageWithQuickStartExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This quick start tile includes prerequisites and a default icon."
       quickStarts={{
         quickStart: monitorSampleAppQuickStart,
@@ -30,7 +27,6 @@ export const MessageWithQuickStartExample: FunctionComponent = () => (
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="This quick start tile is compact"
       quickStarts={{
         quickStart: monitorSampleAppQuickStart,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithResponseActions.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithResponseActions.tsx
@@ -1,14 +1,12 @@
 import { FunctionComponent } from 'react';
 
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 
 export const ResponseActionExample: FunctionComponent = () => (
   <>
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="I updated your account with those settings. You're ready to set up your first dashboard!"
       actions={{
         // eslint-disable-next-line no-console
@@ -27,7 +25,6 @@ export const ResponseActionExample: FunctionComponent = () => (
       name="Bot"
       role="bot"
       showActionsOnInteraction
-      avatar={patternflyAvatar}
       content="This message has response actions visually hidden until you hover over the message via mouse, or an action would receive focus via keyboard."
       actions={{
         // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithSources.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithSources.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { Button, Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -31,7 +30,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example has a custom subtitle and footer with no pagination"
         sources={{
           sources: [
@@ -83,7 +81,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example has a body description that's within the recommended limit of 2 lines:"
         sources={{
           sources: [
@@ -112,7 +109,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example has a body description that's longer than the recommended limit of 2 lines, with a link to load the rest of the description:"
         sources={{
           sources: [
@@ -141,7 +137,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example has a truncated title:"
         sources={{
           sources: [
@@ -164,7 +159,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example only includes 1 source:"
         sources={{
           sources: [
@@ -181,7 +175,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example has a title and no body description:"
         sources={{
           sources: [
@@ -203,7 +196,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example displays the source as a link, without a title (not recommended)"
         sources={{
           sources: [
@@ -223,7 +215,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example displays a compact sources card"
         sources={{
           sources: [
@@ -245,7 +236,6 @@ export const MessageWithSourcesExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This example demonstrates the non-paginated layout option. When enabled, all source cards are displayed in a flex layout that wraps automatically based on available space:"
         sources={{
           sources: [

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolCall.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolCall.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useState } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { Checkbox, Flex, FlexItem } from '@patternfly/react-core';
 
 export const MessageWithToolCallExample: FunctionComponent = () => {
@@ -19,7 +18,6 @@ export const MessageWithToolCallExample: FunctionComponent = () => {
         <Message
           name="Bot"
           role="bot"
-          avatar={patternflyAvatar}
           content="This example has a static tool call title:"
           toolCall={{
             titleText: "Calling 'awesome_tool'",
@@ -30,7 +28,6 @@ export const MessageWithToolCallExample: FunctionComponent = () => {
         <Message
           name="Bot"
           role="bot"
-          avatar={patternflyAvatar}
           content="This example has an expandable tool call title, with an additional description:"
           toolCall={{
             titleText: "Calling 'awesome_tool_expansion'",
@@ -42,7 +39,6 @@ export const MessageWithToolCallExample: FunctionComponent = () => {
         <Message
           name="Bot"
           role="bot"
-          avatar={patternflyAvatar}
           content="This example has an expandable tool call that is expanded by default:"
           toolCall={{
             isDefaultExpanded: true,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/MessageWithToolResponse.tsx
@@ -1,6 +1,5 @@
 import { useState, FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from './patternfly_avatar.jpg';
 import { CopyIcon, WrenchIcon } from '@patternfly/react-icons';
 import {
   Button,
@@ -27,7 +26,6 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This message has a body description that's within the recommended limit of 2 lines:"
         toolResponse={{
           toggleContent: 'Tool response: toolName',
@@ -138,7 +136,6 @@ export const MessageWithToolResponseExample: FunctionComponent = () => {
       <Message
         name="Bot"
         role="bot"
-        avatar={patternflyAvatar}
         content="This message has a tool response that is collapsed by default:"
         toolResponse={{
           isDefaultExpanded: false,

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -336,15 +336,8 @@ _Italic text, formatted with single underscores_
       <Message
         name="User"
         role="user"
-        content="This is a user message with `avatarProps` set to set an avatar color."
-        avatar={userAvatar}
-        avatarProps={{ color: 'blue' }}
-      />
-      <Message
-        name="User"
-        role="user"
-        content="This is a user message with `avatarProps` set to set an avatar with initials."
-        avatarProps={{ initials: 'A' }}
+        content="This is a user message with `avatarProps` set to set an avatar with initials and a blue color."
+        avatarProps={{ initials: 'A', color: 'blue' }}
       />
       <Message name="User" role="user" content="This is a user message with no avatar" />
       <Message

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessage.tsx
@@ -333,6 +333,19 @@ _Italic text, formatted with single underscores_
         avatar={userAvatar}
         avatarProps={{ isBordered: true }}
       />
+      <Message
+        name="User"
+        role="user"
+        content="This is a user message with `avatarProps` set to set an avatar color."
+        avatar={userAvatar}
+        avatarProps={{ color: 'blue' }}
+      />
+      <Message
+        name="User"
+        role="user"
+        content="This is a user message with `avatarProps` set to set an avatar with initials."
+        avatarProps={{ initials: 'A' }}
+      />
       <Message name="User" role="user" content="This is a user message with no avatar" />
       <Message
         name="User"

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessageWithExtraContent.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/Messages/UserMessageWithExtraContent.tsx
@@ -1,7 +1,6 @@
 import { Fragment, FunctionComponent, useState, useEffect } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
 import userAvatar from './user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import {
   Accordion,
   AccordionContent,
@@ -637,7 +636,6 @@ export const UserMessageWithExtraContent: FunctionComponent = () => (
       }}
     />
     <Message
-      avatar={patternflyAvatar}
       name="Bot"
       role="bot"
       content="This is a message with a live progress summmary card."
@@ -647,7 +645,6 @@ export const UserMessageWithExtraContent: FunctionComponent = () => (
       }}
     />
     <Message
-      avatar={patternflyAvatar}
       name="Bot"
       role="bot"
       content="This is a message with a version selector card."
@@ -657,7 +654,6 @@ export const UserMessageWithExtraContent: FunctionComponent = () => (
       }}
     />
     <Message
-      avatar={patternflyAvatar}
       name="Bot"
       role="bot"
       content="All set! I've finished building the Discovery ISO. The next step is to download it and boot your hosts, which you can do using the summary card I've prepared for you:"

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotWelcomeInteraction.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/UI/ChatbotWelcomeInteraction.tsx
@@ -8,7 +8,6 @@ import MessageBar from '@patternfly/chatbot/dist/dynamic/MessageBar';
 import MessageBox from '@patternfly/chatbot/dist/dynamic/MessageBox';
 import Message, { MessageProps } from '@patternfly/chatbot/dist/dynamic/Message';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import { FormGroup, Radio } from '@patternfly/react-core';
 
 export const ChatbotWelcomeInteractionDemo: FunctionComponent = () => {
@@ -50,7 +49,6 @@ export const ChatbotWelcomeInteractionDemo: FunctionComponent = () => {
       content: 'API response goes here',
       name: 'Bot',
       isLoading: true,
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString()
     });
     setMessages(newMessages);
@@ -70,7 +68,6 @@ export const ChatbotWelcomeInteractionDemo: FunctionComponent = () => {
         content: 'API response goes here',
         name: 'Bot',
         isLoading: false,
-        avatar: patternflyAvatar,
         timestamp: date.toLocaleString(),
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Chatbot.tsx
@@ -30,7 +30,6 @@ import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import { getTrackingProviders } from '@patternfly/chatbot/dist/dynamic/tracking';
 import { InitProps } from '@patternfly/chatbot/dist/dynamic/tracking';
 import '@patternfly/react-core/dist/styles/base.css';
@@ -108,7 +107,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       positive: { onClick: () => tracking.trackSingleItem(actionEventName, { response: 'Good response' }) },
@@ -225,7 +223,6 @@ export const ChatbotDemo: FunctionComponent = () => {
       content: 'API response goes here',
       name: 'Bot',
       isLoading: true,
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString()
     });
     setMessages(newMessages);
@@ -245,7 +242,6 @@ export const ChatbotDemo: FunctionComponent = () => {
         content: 'API response goes here',
         name: 'Bot',
         isLoading: false,
-        avatar: patternflyAvatar,
         timestamp: date.toLocaleString(),
         actions: {
           positive: { onClick: () => tracking.trackSingleItem(actionEvent2, { response: 'Good response' }) },

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachment.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachment.tsx
@@ -28,7 +28,6 @@ import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -70,7 +69,6 @@ export const BasicDemo: FunctionComponent = () => {
     {
       role: 'bot',
       content: 'Great, I can reference this attachment throughout our conversation.',
-      avatar: patternflyAvatar,
       name: 'Bot'
     }
   ];

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotAttachmentMenu.tsx
@@ -14,7 +14,6 @@ import FileDetailsLabel from '@patternfly/chatbot/dist/dynamic/FileDetailsLabel'
 import { BellIcon, CalendarAltIcon, ClipboardIcon, CodeIcon, UploadIcon } from '@patternfly/react-icons';
 import { useDropzone } from 'react-dropzone';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 import { cloneElement, FunctionComponent, isValidElement, ReactNode, useState, Children } from 'react';
@@ -79,8 +78,7 @@ const messages: MessageProps[] = [
   {
     role: 'bot',
     content: 'I sure can!',
-    name: 'Bot',
-    avatar: patternflyAvatar
+    name: 'Bot'
   }
 ];
 

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotCompact.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotCompact.tsx
@@ -30,7 +30,6 @@ import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 
 const footnoteProps = {
   label: 'Always review AI-generated content prior to use.'
@@ -89,7 +88,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -208,7 +206,6 @@ export const ChatbotDemo: FunctionComponent = () => {
       content: 'API response goes here',
       name: 'Bot',
       isLoading: true,
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString()
     });
     setMessages(newMessages);
@@ -228,7 +225,6 @@ export const ChatbotDemo: FunctionComponent = () => {
         content: 'API response goes here',
         name: 'Bot',
         isLoading: false,
-        avatar: patternflyAvatar,
         timestamp: date.toLocaleString(),
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotDisplayMode.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotDisplayMode.tsx
@@ -48,7 +48,6 @@ import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import OpenDrawerRightIcon from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
 import OutlinedWindowRestoreIcon from '@patternfly/react-icons/dist/esm/icons/outlined-window-restore-icon';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -75,7 +74,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -198,7 +196,6 @@ export const ChatbotDisplayModeDemo: FunctionComponent = () => {
       role: 'bot',
       content: 'API response goes here',
       name: 'Bot',
-      avatar: patternflyAvatar,
       isLoading: true,
       timestamp: date.toLocaleString()
     });
@@ -213,7 +210,6 @@ export const ChatbotDisplayModeDemo: FunctionComponent = () => {
         role: 'bot',
         content: 'API response goes here',
         name: 'Bot',
-        avatar: patternflyAvatar,
         isLoading: false,
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotInDrawer.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotInDrawer.tsx
@@ -41,7 +41,6 @@ import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import { BarsIcon } from '@patternfly/react-icons';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -102,7 +101,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -218,7 +216,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
       role: 'bot',
       content: 'API response goes here',
       name: 'Bot',
-      avatar: patternflyAvatar,
       isLoading: true,
       timestamp: date.toLocaleString()
     });
@@ -238,7 +235,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
         role: 'bot',
         content: 'API response goes here',
         name: 'Bot',
-        avatar: patternflyAvatar,
         isLoading: false,
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotScrolling.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotScrolling.tsx
@@ -31,7 +31,6 @@ import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -94,7 +93,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -233,7 +231,6 @@ export const ChatbotScrollingDemo: React.FunctionComponent = () => {
       content: 'API response goes here',
       name: 'Bot',
       isLoading: true,
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString()
     });
     setMessages(newMessages);
@@ -255,7 +252,6 @@ export const ChatbotScrollingDemo: React.FunctionComponent = () => {
         content: 'API response goes here.',
         name: 'Bot',
         isLoading: false,
-        avatar: patternflyAvatar,
         timestamp: date.toLocaleString(),
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotTranscripts.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/ChatbotTranscripts.tsx
@@ -30,7 +30,6 @@ import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import PFIconLogoColor from '../UI/PF-IconLogo-Color.svg';
 import PFIconLogoReverse from '../UI/PF-IconLogo-Reverse.svg';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 import saveAs from 'file-saver';
@@ -182,7 +181,6 @@ export const ChatbotDemo: FunctionComponent = () => {
       role: 'bot',
       content: markdown,
       name: 'Bot',
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString(),
       actions: {
         download: {
@@ -193,7 +191,6 @@ export const ChatbotDemo: FunctionComponent = () => {
                 role: 'bot',
                 content: markdown,
                 name: 'Bot',
-                avatar: patternflyAvatar,
                 timestamp: date.toLocaleString()
               },
               selectedModel
@@ -292,7 +289,6 @@ export const ChatbotDemo: FunctionComponent = () => {
       content: 'API response goes here',
       name: 'Bot',
       isLoading: true,
-      avatar: patternflyAvatar,
       timestamp: date.toLocaleString()
     });
     setMessages(newMessages);
@@ -308,7 +304,6 @@ export const ChatbotDemo: FunctionComponent = () => {
       loadedMessages.pop();
       const id = generateId();
       const timestamp = date.toLocaleString();
-      const avatar = patternflyAvatar;
       const name = 'Bot';
       const content = 'API response goes here';
       const role = 'bot';
@@ -318,7 +313,6 @@ export const ChatbotDemo: FunctionComponent = () => {
         content,
         name,
         isLoading: false,
-        avatar,
         timestamp,
         actions: {
           download: {
@@ -329,7 +323,6 @@ export const ChatbotDemo: FunctionComponent = () => {
                   role,
                   content,
                   name,
-                  avatar,
                   timestamp
                 },
                 selectedModel

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedChatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedChatbot.tsx
@@ -39,7 +39,6 @@ import PFHorizontalLogoColor from '../UI/PF-HorizontalLogo-Color.svg';
 import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import { BarsIcon } from '@patternfly/react-icons';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -100,7 +99,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -209,7 +207,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
       role: 'bot',
       content: 'API response goes here',
       name: 'Bot',
-      avatar: patternflyAvatar,
       isLoading: true,
       timestamp: date.toLocaleString()
     });
@@ -229,7 +226,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
         role: 'bot',
         content: 'API response goes here',
         name: 'Bot',
-        avatar: patternflyAvatar,
         isLoading: false,
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedComparisonChatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedComparisonChatbot.tsx
@@ -22,7 +22,6 @@ import ChatbotHeader, { ChatbotHeaderMain } from '@patternfly/chatbot/dist/dynam
 import Compare from '@patternfly/chatbot/dist/dynamic/Compare';
 import { BarsIcon } from '@patternfly/react-icons';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -53,7 +52,6 @@ export const CompareChild = ({ name, input, hasNewInput, setIsSendButtonDisabled
         timestamp: `${date?.toLocaleDateString()} ${date?.toLocaleTimeString()}`
       });
       newMessages.push({
-        avatar: patternflyAvatar,
         id: generateId(),
         name,
         role: 'bot',
@@ -76,7 +74,6 @@ export const CompareChild = ({ name, input, hasNewInput, setIsSendButtonDisabled
           role: 'bot',
           content: `API response from ${name} goes here`,
           name,
-          avatar: patternflyAvatar,
           isLoading: false,
           actions: {
             // eslint-disable-next-line no-console

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Feedback.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/Feedback.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useState, useRef } from 'react';
 import Message from '@patternfly/chatbot/dist/dynamic/Message';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -37,7 +36,6 @@ export const MessageWithFeedbackExample: FunctionComponent = () => {
     <Message
       name="Bot"
       role="bot"
-      avatar={patternflyAvatar}
       content="Bot message with user feedback flow; click on a message action to launch the feedback flow. Click submit to see the thank-you message."
       actions={{
         positive: {

--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/WhiteEmbeddedChatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/WhiteEmbeddedChatbot.tsx
@@ -39,7 +39,6 @@ import PFHorizontalLogoColor from '../UI/PF-HorizontalLogo-Color.svg';
 import PFHorizontalLogoReverse from '../UI/PF-HorizontalLogo-Reverse.svg';
 import { BarsIcon } from '@patternfly/react-icons';
 import userAvatar from '../Messages/user_avatar.svg';
-import patternflyAvatar from '../Messages/patternfly_avatar.jpg';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/chatbot/dist/css/main.css';
 
@@ -109,7 +108,6 @@ const initialMessages: MessageProps[] = [
     role: 'bot',
     content: markdown,
     name: 'Bot',
-    avatar: patternflyAvatar,
     timestamp: date.toLocaleString(),
     actions: {
       // eslint-disable-next-line no-console
@@ -221,7 +219,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
       role: 'bot',
       content: 'API response goes here',
       name: 'Bot',
-      avatar: patternflyAvatar,
       isLoading: true,
       timestamp: date.toLocaleString(),
       isPrimary: true
@@ -242,7 +239,6 @@ export const EmbeddedChatbotDemo: FunctionComponent = () => {
         role: 'bot',
         content: 'API response goes here',
         name: 'Bot',
-        avatar: patternflyAvatar,
         isLoading: false,
         actions: {
           // eslint-disable-next-line no-console

--- a/packages/module/src/Message/Message.scss
+++ b/packages/module/src/Message/Message.scss
@@ -11,10 +11,15 @@
   // --------------------------------------------------------------------------
   &-avatar.pf-v6-c-avatar {
     --pf-v6-c-avatar--BorderRadius: 0;
+    flex-shrink: 0;
     position: sticky;
     top: var(--pf-t--global--spacer--md);
     object-fit: cover;
     pointer-events: none; // prevent dragging - interferes with FileDropZone
+  }
+
+  &-avatar.pf-v6-c-avatar:not(.pf-m-colorful) {
+    --pf-v6-c-avatar--BackgroundColor: var(--pf-t--global--background--color--floating--default);
   }
 
   &-avatar.pf-chatbot__message-avatar--round.pf-v6-c-avatar {

--- a/packages/module/src/Message/Message.test.tsx
+++ b/packages/module/src/Message/Message.test.tsx
@@ -242,11 +242,23 @@ describe('Message', () => {
     ).toBeInTheDocument();
   });
   it('should render avatar correctly', () => {
-    render(<Message avatar="./testImg" role="bot" name="Bot" content="Hi" />);
+    render(<Message avatar="./testImg" role="user" name="A" content="Hi" />);
     expect(screen.getByRole('img')).toHaveAttribute('src', './testImg');
   });
   it('should not render avatar if no avatar prop is passed', () => {
+    render(<Message role="user" name="A" content="Hi" />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+  it('should render bot avatar if no avatar prop is passed', () => {
     render(<Message role="bot" name="Bot" content="Hi" />);
+    expect(screen.queryAllByRole('img', { hidden: true })[0]).toBeVisible();
+  });
+  it('should not render avatar if isAvatarHidden is passed', () => {
+    render(<Message role="user" name="A" content="Hi" isAvatarHidden />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+  it('should not render bot avatar if isAvatarHidden is passed', () => {
+    render(<Message role="bot" name="Bot" content="Hi" isAvatarHidden />);
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
   it('should render botWord correctly', () => {

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -85,7 +85,7 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   extraContent?: MessageExtraContent;
   /** Name of the user */
   name?: string;
-  /** Avatar for the user. Pass a string for an image src, or a ReactNode for custom content like an svg or icon. Avatars for Messages withrole="bot" are pre-defined and not customizable. */
+  /** Avatar for the user. Pass a string for an image src, or a ReactNode for custom content like an svg or icon. Avatars for Messages with role="bot" are pre-defined and not customizable. */
   avatar?: string | ReactNode;
   /** Flag indicating whether the avatar is hidden */
   isAvatarHidden?: boolean;

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -85,7 +85,7 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   extraContent?: MessageExtraContent;
   /** Name of the user */
   name?: string;
-  /** Avatar src for the user */
+  /** Avatar for the user. Pass a string for an image src, or a ReactNode for custom content like an svg or icon. */
   avatar?: string | ReactNode;
   /** Flag indicating whether the avatar is hidden */
   isAvatarHidden?: boolean;

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -36,6 +36,7 @@ import DeepThinking, { DeepThinkingProps } from '../DeepThinking';
 import ToolCall, { ToolCallProps } from '../ToolCall';
 import MarkdownContent from '../MarkdownContent';
 import { css } from '@patternfly/react-styles';
+import RhUiAiChatbotIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-ai-chatbot-icon';
 
 export interface MessageAttachment {
   /** Name of file attached to the message */
@@ -326,6 +327,34 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
     );
   };
 
+  /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
+  const defaultAvatar = (
+    <Avatar
+      className={`pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`}
+      src={avatar}
+      alt=""
+      {...avatarProps}
+    />
+  );
+
+  const botAvatar = (
+    <Avatar
+      className={`pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`}
+      alt=""
+      {...avatarProps}
+    >
+      <RhUiAiChatbotIcon />
+    </Avatar>
+  );
+
+  let _avatar: ReactNode | undefined;
+
+  if (avatar) {
+    _avatar = defaultAvatar;
+  } else if (role === 'bot') {
+    _avatar = botAvatar;
+  }
+
   return (
     <section
       aria-label={`Message from ${role} - ${dateString}`}
@@ -335,15 +364,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
       ref={innerRef}
       {...props}
     >
-      {/* We are using an empty alt tag intentionally in order to reduce noise on screen readers */}
-      {avatar && (
-        <Avatar
-          className={`pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`}
-          src={avatar}
-          alt=""
-          {...avatarProps}
-        />
-      )}
+      {_avatar && _avatar}
       <div className="pf-chatbot__message-contents">
         {isMetadataVisible && (
           <div className="pf-chatbot__message-meta">

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -86,7 +86,7 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   /** Name of the user */
   name?: string;
   /** Avatar src for the user */
-  avatar?: string;
+  avatar?: string | ReactNode;
   /** Flag indicating whether the avatar is hidden */
   isAvatarHidden?: boolean;
   /** Timestamp for the message */
@@ -335,8 +335,6 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
   );
 
   /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
-  const defaultAvatar = <Avatar className={avatarClasses} src={avatar} alt="" {...avatarProps} />;
-
   const botAvatar = (
     <Avatar className={avatarClasses} alt="" {...avatarProps}>
       <RhUiAiChatbotIcon />
@@ -347,7 +345,16 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
 
   if (!isAvatarHidden) {
     if (avatar) {
-      _avatar = defaultAvatar;
+      _avatar =
+        typeof avatar === 'string' ? (
+          <Avatar className={avatarClasses} src={avatar} alt="" {...avatarProps} />
+        ) : (
+          <Avatar className={avatarClasses} alt="" {...avatarProps}>
+            {avatar}
+          </Avatar>
+        );
+    } else if (avatarProps?.initials) {
+      _avatar = <Avatar className={avatarClasses} alt="" {...avatarProps} />;
     } else if (role === 'bot') {
       _avatar = botAvatar;
     }

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -336,7 +336,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
 
   /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
   const botAvatar = (
-    <Avatar className={avatarClasses} alt="" {...avatarProps}>
+    <Avatar className={avatarClasses} alt="" isBordered {...avatarProps}>
       <RhUiAiChatbotIcon />
     </Avatar>
   );

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -85,7 +85,7 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   extraContent?: MessageExtraContent;
   /** Name of the user */
   name?: string;
-  /** Avatar for the user. Pass a string for an image src, or a ReactNode for custom content like an svg or icon. */
+  /** Avatar for the user. Pass a string for an image src, or a ReactNode for custom content like an svg or icon. Avatars for Messages withrole="bot" are pre-defined and not customizable. */
   avatar?: string | ReactNode;
   /** Flag indicating whether the avatar is hidden */
   isAvatarHidden?: boolean;
@@ -336,7 +336,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
 
   /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
   const botAvatar = (
-    <Avatar className={avatarClasses} alt="" isBordered {...avatarProps}>
+    <Avatar className={avatarClasses} alt="" isBordered {...avatarProps} src={undefined} initials={undefined}>
       <RhUiAiChatbotIcon />
     </Avatar>
   );
@@ -344,7 +344,9 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
   let _avatar: ReactNode | undefined;
 
   if (!isAvatarHidden) {
-    if (avatar) {
+    if (role === 'bot') {
+      _avatar = botAvatar;
+    } else if (avatar) {
       _avatar =
         typeof avatar === 'string' ? (
           <Avatar className={avatarClasses} src={avatar} alt="" {...avatarProps} />
@@ -355,8 +357,6 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
         );
     } else if (avatarProps?.initials) {
       _avatar = <Avatar className={avatarClasses} alt="" {...avatarProps} />;
-    } else if (role === 'bot') {
-      _avatar = botAvatar;
     }
   }
 

--- a/packages/module/src/Message/Message.tsx
+++ b/packages/module/src/Message/Message.tsx
@@ -87,6 +87,8 @@ export interface MessageProps extends Omit<HTMLProps<HTMLDivElement>, 'role'> {
   name?: string;
   /** Avatar src for the user */
   avatar?: string;
+  /** Flag indicating whether the avatar is hidden */
+  isAvatarHidden?: boolean;
   /** Timestamp for the message */
   timestamp?: string;
   /** Set this to true if message is being loaded */
@@ -215,6 +217,7 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
   extraContent,
   name,
   avatar,
+  isAvatarHidden = false,
   timestamp,
   isLoading,
   actions,
@@ -327,32 +330,27 @@ export const MessageBase: FunctionComponent<MessageProps> = ({
     );
   };
 
-  /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
-  const defaultAvatar = (
-    <Avatar
-      className={`pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`}
-      src={avatar}
-      alt=""
-      {...avatarProps}
-    />
+  const avatarClasses = css(
+    `pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`
   );
 
+  /* We are using an empty alt tag intentionally in order to reduce noise on screen readers */
+  const defaultAvatar = <Avatar className={avatarClasses} src={avatar} alt="" {...avatarProps} />;
+
   const botAvatar = (
-    <Avatar
-      className={`pf-chatbot__message-avatar ${hasRoundAvatar ? 'pf-chatbot__message-avatar--round' : ''} ${avatarClassName ? avatarClassName : ''}`}
-      alt=""
-      {...avatarProps}
-    >
+    <Avatar className={avatarClasses} alt="" {...avatarProps}>
       <RhUiAiChatbotIcon />
     </Avatar>
   );
 
   let _avatar: ReactNode | undefined;
 
-  if (avatar) {
-    _avatar = defaultAvatar;
-  } else if (role === 'bot') {
-    _avatar = botAvatar;
+  if (!isAvatarHidden) {
+    if (avatar) {
+      _avatar = defaultAvatar;
+    } else if (role === 'bot') {
+      _avatar = botAvatar;
+    }
   }
 
   return (


### PR DESCRIPTION
Closes: #816


Todos -
- [x] pull in new prerelease react versions for Avatar update testing
- [x] update examples: remove `avatar` src prop from all bot message examples
- [x] update any tests
- [ ] pull in new stable versions for Avatar update (6.6)

Open question -
- Do we want to try to set the bot avatar by default like I currently have the logic in `Message` or would we prefer to instead expand `avatar`'s allowed types to let users pass in the `RhUiAiChatbotIcon` themselves? Answer - yes to default Avatar, also allowed other types.