### PR TITLE
fix(ChatBot): Remove custom font size

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedComparisonChatbot.tsx
+++ b/packages/module/patternfly-docs/content/extensions/chatbot/examples/demos/EmbeddedComparisonChatbot.tsx
@@ -18,7 +18,7 @@ import ChatbotFooter from '@patternfly/chatbot/dist/dynamic/ChatbotFooter';
 import MessageBar from '@patternfly/chatbot/dist/dynamic/MessageBar';
 import MessageBox from '@patternfly/chatbot/dist/dynamic/MessageBox';
 import Message, { MessageProps } from '@patternfly/chatbot/dist/dynamic/Message';
-import ChatbotHeader, { ChatbotHeaderMain } from '@patternfly/chatbot/dist/dynamic/ChatbotHeader';
+import ChatbotHeader, { ChatbotHeaderMain, ChatbotHeaderTitle } from '@patternfly/chatbot/dist/dynamic/ChatbotHeader';
 import Compare from '@patternfly/chatbot/dist/dynamic/Compare';
 import { BarsIcon } from '@patternfly/react-icons';
 import userAvatar from '../Messages/user_avatar.svg';
@@ -118,7 +118,9 @@ export const CompareChild = ({ name, input, hasNewInput, setIsSendButtonDisabled
   return (
     <Chatbot displayMode={displayMode}>
       <ChatbotHeader>
-        <ChatbotHeaderMain>{name}</ChatbotHeaderMain>
+        <ChatbotHeaderMain>
+          <ChatbotHeaderTitle>{name}</ChatbotHeaderTitle>
+        </ChatbotHeaderMain>
       </ChatbotHeader>
       <ChatbotContent>
         <MessageBox ariaLabel={`Scrollable message log for ${name}`} announcement={announcement}>

--- a/packages/module/src/Chatbot/Chatbot.scss
+++ b/packages/module/src/Chatbot/Chatbot.scss
@@ -15,7 +15,6 @@
   );
   border-radius: var(--pf-t--global--border--radius--medium);
   box-shadow: var(--pf-t--global--box-shadow--lg);
-  font-size: var(--pf-t--global--font--size--md);
   z-index: var(--pf-t--global--z-index--md);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -162,9 +161,3 @@
   }
 }
 
-// ============================================================================
-// Information density styles
-// ============================================================================
-.pf-chatbot.pf-m-compact {
-  font-size: var(--pf-t--global--font--size--sm);
-}

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.scss
@@ -48,7 +48,7 @@
 
   // Drawer menu
   // ----------------------------------------------------------------------------
-  .pf-v6-c-menu {
+  .pf-v6-c-menu.pf-chatbot__history-menu {
     --pf-v6-c-menu--PaddingBlockStart: 0;
     --pf-v6-c-menu--BackgroundColor: var(--pf-t--global--background--color--floating--default);
     // override high contrast style

--- a/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
+++ b/packages/module/src/ChatbotConversationHistoryNav/ChatbotConversationHistoryNav.tsx
@@ -290,7 +290,13 @@ export const ChatbotConversationHistoryNav: FunctionComponent<ChatbotConversatio
       return <HistoryEmptyState {...noResultsState} />;
     }
     return (
-      <Menu isPlain onSelect={onSelectActiveItem} activeItemId={activeItemId} {...menuProps}>
+      <Menu
+        className="pf-chatbot__history-menu"
+        isPlain
+        onSelect={onSelectActiveItem}
+        activeItemId={activeItemId}
+        {...menuProps}
+      >
         <MenuContent {...menuContentProps}>{buildConversations()}</MenuContent>
       </Menu>
     );

--- a/packages/module/src/ChatbotHeader/ChatbotHeader.scss
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.scss
@@ -5,7 +5,6 @@
   display: grid;
 }
 .pf-chatbot__header {
-  font-size: var(--pf-t--global--font--size--md);
   display: grid;
   grid-template-columns: 1fr auto;
   gap: var(--pf-t--global--spacer--sm);
@@ -28,6 +27,7 @@
 
   // Title -or- Brand
   .pf-chatbot__title {
+    font-size:  var(--pf-t--global--font--size--body--lg);
     display: flex;
     align-items: center;
     flex: 1;

--- a/packages/module/src/ChatbotHeader/ChatbotHeader.scss
+++ b/packages/module/src/ChatbotHeader/ChatbotHeader.scss
@@ -5,6 +5,7 @@
   display: grid;
 }
 .pf-chatbot__header {
+  font-size: var(--pf-t--global--font--size--md);
   display: grid;
   grid-template-columns: 1fr auto;
   gap: var(--pf-t--global--spacer--sm);


### PR DESCRIPTION
Use PatternFly default of 14px rather than 16px.

Fixes https://github.com/patternfly/chatbot/issues/853.

I did notice these arrows seem funky

| Ours | Main Site |
|-|-|
|<img width="279" height="71" alt="Screenshot 2026-07-01 at 1 55 15 PM" src="https://github.com/user-attachments/assets/c44ffccb-6de3-4c3b-a74d-fb0589101c94" />|<img width="275" height="69" alt="Screenshot 2026-07-01 at 1 55 19 PM" src="https://github.com/user-attachments/assets/6ea601f3-9197-408e-8a2e-61d0b17c914f" />
